### PR TITLE
Embedded/add esp32 project gen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ indicatif = "0.17"
 colored = "2"
 dirs = "5"
 toml = "0.8"
+which = "8.0.0"
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // Create completions directory
     let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let completions_dir = project_root.join("completions");
-    
+
     if !completions_dir.exists() {
         fs::create_dir_all(&completions_dir).expect("Failed to create completions directory");
     }

--- a/install.sh
+++ b/install.sh
@@ -17,119 +17,129 @@ BINARY_NAME="cargo-forge"
 
 # Detect OS and architecture
 detect_platform() {
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-    ARCH=$(uname -m)
-    
-    case "$OS" in
-        linux)
-            case "$ARCH" in
-                x86_64) PLATFORM="x86_64-linux" ;;
-                aarch64) PLATFORM="aarch64-linux" ;;
-                *) echo "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
-            esac
-            ;;
-        darwin)
-            case "$ARCH" in
-                x86_64) PLATFORM="x86_64-macos" ;;
-                arm64) PLATFORM="aarch64-macos" ;;
-                *) echo "${RED}Unsupported architecture: $ARCH${NC}"; exit 1 ;;
-            esac
-            ;;
-        *) echo "${RED}Unsupported OS: $OS${NC}"; exit 1 ;;
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  ARCH=$(uname -m)
+
+  case "$OS" in
+  linux)
+    case "$ARCH" in
+    x86_64) PLATFORM="x86_64-linux" ;;
+    aarch64) PLATFORM="aarch64-linux" ;;
+    *)
+      echo "${RED}Unsupported architecture: $ARCH${NC}"
+      exit 1
+      ;;
     esac
+    ;;
+  darwin)
+    case "$ARCH" in
+    x86_64) PLATFORM="x86_64-macos" ;;
+    arm64) PLATFORM="aarch64-macos" ;;
+    *)
+      echo "${RED}Unsupported architecture: $ARCH${NC}"
+      exit 1
+      ;;
+    esac
+    ;;
+  *)
+    echo "${RED}Unsupported OS: $OS${NC}"
+    exit 1
+    ;;
+  esac
 }
 
 # Get latest release version
 get_latest_version() {
-    curl -s "https://api.github.com/repos/$REPO/releases/latest" | \
-        grep '"tag_name":' | \
-        sed -E 's/.*"([^"]+)".*/\1/'
+  curl -s "https://api.github.com/repos/$REPO/releases/latest" |
+    grep '"tag_name":' |
+    sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Download and install
 install_cargo_forge() {
-    echo "${GREEN}Installing cargo-forge...${NC}"
-    
-    # Detect platform
-    detect_platform
-    echo "Detected platform: $PLATFORM"
-    
-    # Get latest version
-    VERSION=$(get_latest_version)
-    if [ -z "$VERSION" ]; then
-        echo "${RED}Failed to get latest version${NC}"
-        exit 1
-    fi
-    echo "Latest version: $VERSION"
-    
-    # Construct download URL
-    DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/cargo-forge-$PLATFORM.tar.gz"
-    echo "Download URL: $DOWNLOAD_URL"
-    
-    # Create temporary directory
-    TMP_DIR=$(mktemp -d)
-    cd "$TMP_DIR"
-    
-    # Download binary
-    echo "Downloading cargo-forge..."
-    if ! curl -sL "$DOWNLOAD_URL" -o cargo-forge.tar.gz; then
-        echo "${RED}Failed to download cargo-forge${NC}"
-        exit 1
-    fi
-    
-    # Extract binary
-    echo "Extracting..."
-    tar xzf cargo-forge.tar.gz
-    
-    # Create install directory if it doesn't exist
-    mkdir -p "$INSTALL_DIR"
-    
-    # Install binary
-    echo "Installing to $INSTALL_DIR..."
-    if ! mv cargo-forge "$INSTALL_DIR/"; then
-        echo "${RED}Failed to install cargo-forge. Try running with sudo or check permissions.${NC}"
-        exit 1
-    fi
-    
-    # Make executable
-    chmod +x "$INSTALL_DIR/$BINARY_NAME"
-    
-    # Cleanup
-    cd ..
-    rm -rf "$TMP_DIR"
-    
-    # Verify installation
-    if command -v cargo-forge >/dev/null 2>&1; then
-        echo "${GREEN}✓ cargo-forge installed successfully!${NC}"
-        echo "Version: $(cargo-forge --version)"
-        echo ""
-        echo "To get started, run:"
-        echo "  ${YELLOW}cargo-forge new${NC}"
-        echo ""
-        echo "For shell completions, see:"
-        echo "  ${YELLOW}cargo-forge completions --help${NC}"
-    else
-        echo "${YELLOW}cargo-forge installed to $INSTALL_DIR${NC}"
-        echo "Make sure $INSTALL_DIR is in your PATH:"
-        echo "  ${YELLOW}export PATH=\"$INSTALL_DIR:\$PATH\"${NC}"
-    fi
+  echo "${GREEN}Installing cargo-forge...${NC}"
+
+  # Detect platform
+  detect_platform
+  echo "Detected platform: $PLATFORM"
+
+  # Get latest version
+  VERSION=$(get_latest_version)
+  if [ -z "$VERSION" ]; then
+    echo "${RED}Failed to get latest version${NC}"
+    exit 1
+  fi
+  echo "Latest version: $VERSION"
+
+  # Construct download URL
+  DOWNLOAD_URL="https://github.com/$REPO/releases/download/$VERSION/cargo-forge-$PLATFORM.tar.gz"
+  echo "Download URL: $DOWNLOAD_URL"
+
+  # Create temporary directory
+  TMP_DIR=$(mktemp -d)
+  cd "$TMP_DIR"
+
+  # Download binary
+  echo "Downloading cargo-forge..."
+  if ! curl -sL "$DOWNLOAD_URL" -o cargo-forge.tar.gz; then
+    echo "${RED}Failed to download cargo-forge${NC}"
+    exit 1
+  fi
+
+  # Extract binary
+  echo "Extracting..."
+  tar xzf cargo-forge.tar.gz
+
+  # Create install directory if it doesn't exist
+  mkdir -p "$INSTALL_DIR"
+
+  # Install binary
+  echo "Installing to $INSTALL_DIR..."
+  if ! mv cargo-forge "$INSTALL_DIR/"; then
+    echo "${RED}Failed to install cargo-forge. Try running with sudo or check permissions.${NC}"
+    exit 1
+  fi
+
+  # Make executable
+  chmod +x "$INSTALL_DIR/$BINARY_NAME"
+
+  # Cleanup
+  cd ..
+  rm -rf "$TMP_DIR"
+
+  # Verify installation
+  if command -v cargo-forge >/dev/null 2>&1; then
+    echo "${GREEN}✓ cargo-forge installed successfully!${NC}"
+    echo "Version: $(cargo-forge --version)"
+    echo ""
+    echo "To get started, run:"
+    echo "  ${YELLOW}cargo-forge new${NC}"
+    echo ""
+    echo "For shell completions, see:"
+    echo "  ${YELLOW}cargo-forge completions --help${NC}"
+  else
+    echo "${YELLOW}cargo-forge installed to $INSTALL_DIR${NC}"
+    echo "Make sure $INSTALL_DIR is in your PATH:"
+    echo "  ${YELLOW}export PATH=\"$INSTALL_DIR:\$PATH\"${NC}"
+  fi
 }
 
 # Main
 main() {
-    echo "${GREEN}⚒️  Cargo-Forge Installer${NC}"
-    echo ""
-    
-    # Check for curl
-    if ! command -v curl >/dev/null 2>&1; then
-        echo "${RED}Error: curl is required but not installed.${NC}"
-        echo "Please install curl and try again."
-        exit 1
-    fi
-    
-    # Run installation
-    install_cargo_forge
+  echo "${GREEN}⚒️  Cargo-Forge Installer${NC}"
+  echo ""
+
+  # Check for curl
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "${RED}Error: curl is required but not installed.${NC}"
+    echo "Please install curl and try again."
+    exit 1
+  fi
+
+  # Run installation
+  install_cargo_forge
 }
 
 # Run main function
 main
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,63 +20,71 @@ pub enum Commands {
         /// Project name
         #[arg(help = "Name of the project to create")]
         name: Option<String>,
-        
+
         /// Project type
-        #[arg(short, long, help = "Type of project (api-server, cli-tool, library, wasm-app, game-engine, embedded, workspace)")]
+        #[arg(
+            short,
+            long,
+            help = "Type of project (api-server, cli-tool, library, wasm-app, game-engine, embedded, workspace)"
+        )]
         project_type: Option<String>,
-        
+
         /// Author name
         #[arg(short, long, help = "Author name for the project")]
         author: Option<String>,
-        
+
         /// Project description
         #[arg(short, long, help = "Description of the project")]
         description: Option<String>,
-        
+
         /// License
         #[arg(short, long, help = "License for the project")]
         license: Option<String>,
-        
+
         /// Non-interactive mode with defaults for CI usage
         #[arg(long, help = "Use defaults without prompting (for CI environments)")]
         non_interactive: bool,
-        
+
         /// Use configuration from file
         #[arg(long, help = "Use saved preferences from config file")]
         from_config: Option<PathBuf>,
-        
+
         /// Dry run mode - preview without creating files
         #[arg(long, help = "Preview the project structure without creating files")]
         dry_run: bool,
     },
-    
+
     /// Initialize a new project in the current directory
     Init {
         /// Project type
-        #[arg(short, long, help = "Type of project (api-server, cli-tool, library, wasm-app, game-engine, embedded, workspace)")]
+        #[arg(
+            short,
+            long,
+            help = "Type of project (api-server, cli-tool, library, wasm-app, game-engine, embedded, workspace)"
+        )]
         project_type: Option<String>,
-        
+
         /// Author name
         #[arg(short, long, help = "Author name for the project")]
         author: Option<String>,
-        
+
         /// License
         #[arg(short, long, help = "License for the project")]
         license: Option<String>,
-        
+
         /// Non-interactive mode with defaults for CI usage
         #[arg(long, help = "Use defaults without prompting (for CI environments)")]
         non_interactive: bool,
-        
+
         /// Use configuration from file
         #[arg(long, help = "Use saved preferences from config file")]
         from_config: Option<PathBuf>,
-        
+
         /// Dry run mode - preview without creating files
         #[arg(long, help = "Preview the project structure without creating files")]
         dry_run: bool,
     },
-    
+
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
-use serde::{Deserialize, Serialize};
-use anyhow::{Result, Context};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -46,17 +46,17 @@ impl Config {
     /// Load config from a specific file path
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
-        
+
         if !path.exists() {
             return Ok(Self::new());
         }
 
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read config file: {}", path.display()))?;
-        
+
         let config: Config = toml::from_str(&content)
             .with_context(|| format!("Failed to parse config file: {}", path.display()))?;
-        
+
         Ok(config)
     }
 
@@ -79,19 +79,19 @@ impl Config {
     /// Save config to a specific file path
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let path = path.as_ref();
-        
+
         // Create parent directory if it doesn't exist
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create config directory: {}", parent.display())
+            })?;
         }
 
-        let content = toml::to_string_pretty(self)
-            .context("Failed to serialize config to TOML")?;
-        
+        let content = toml::to_string_pretty(self).context("Failed to serialize config to TOML")?;
+
         fs::write(path, content)
             .with_context(|| format!("Failed to write config file: {}", path.display()))?;
-        
+
         Ok(())
     }
 

--- a/src/external_generators.rs
+++ b/src/external_generators.rs
@@ -1,0 +1,103 @@
+use anyhow::{Context, Result};
+use std::process::Command;
+
+pub fn generate_esp32_project(
+    project_name: &str,
+    chip: &str,
+    output_dir: &std::path::Path,
+) -> Result<()> {
+    println!("🔍 Debug: Checking esp-generate installation...");
+
+    // First, check if esp-generate exists
+    let help_output = Command::new("esp-generate").arg("--help").output();
+
+    match help_output {
+        Ok(_) => {
+            println!("✅ esp-generate found");
+        }
+        Err(e) => {
+            println!("❌ esp-generate not found: {}", e);
+            println!("📦 Installing esp-generate...");
+
+            let install_status = Command::new("cargo")
+                .args(["install", "esp-generate", "--locked"])
+                .status()
+                .context("Failed to install esp-generate")?;
+
+            if !install_status.success() {
+                return Err(anyhow::anyhow!("Failed to install esp-generate"));
+            }
+            println!("✅ esp-generate installed successfully");
+        }
+    }
+
+    println!("🚀 Running esp-generate TUI for:");
+    println!("  Chip: {}", chip);
+    println!("  Project name: {}", project_name);
+    println!("  Output directory: {}", output_dir.display());
+    println!("📋 esp-generate will now open its interactive interface...\n");
+
+    // Use .status() instead of .output() to allow TUI interaction
+    let status = Command::new("esp-generate")
+        .args([
+            "--chip",
+            chip,
+            "--output-path",
+            output_dir.to_str().unwrap(),
+            project_name,
+        ])
+        .status() // This allows the TUI to interact with the terminal
+        .context("Failed to run esp-generate command")?;
+
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "esp-generate failed with exit code: {:?}",
+            status.code()
+        ));
+    }
+
+    println!("\n✅ ESP32 project generated successfully!");
+    println!(
+        "💡 Run 'cd {}/{} && cargo build' to build your project",
+        output_dir.display(),
+        project_name
+    );
+
+    Ok(())
+}
+
+pub fn esp32_chip_options() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("esp32", "ESP32 (Xtensa, dual-core)"),
+        ("esp32s2", "ESP32-S2 (Xtensa, single-core, USB)"),
+        ("esp32s3", "ESP32-S3 (Xtensa, dual-core, USB)"),
+        ("esp32c3", "ESP32-C3 (RISC-V, single-core, WiFi/BLE)"),
+        ("esp32c6", "ESP32-C6 (RISC-V, single-core, WiFi 6)"),
+        ("esp32h2", "ESP32-H2 (RISC-V, single-core, Thread/Zigbee)"),
+    ]
+}
+
+pub fn interactive_esp32_chip_selection() -> Result<String> {
+    use inquire::Select;
+
+    let chip_data = esp32_chip_options();
+    let display_options: Vec<String> = chip_data
+        .iter()
+        .map(|(chip, description)| format!("{} - {}", chip.to_uppercase(), description))
+        .collect();
+
+    let selection = Select::new("Select ESP32 chip type:", display_options)
+        .with_help_message("Choose the ESP32 variant for your project")
+        .prompt()?;
+
+    // Find the matching chip from the original data
+    let selected_chip = chip_data
+        .iter()
+        .find(|(chip, description)| {
+            format!("{} - {}", chip.to_uppercase(), description) == selection
+        })
+        .map(|(chip, _)| chip.to_string())
+        .unwrap_or_else(|| "esp32c6".to_string());
+
+    Ok(selected_chip)
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -1,9 +1,9 @@
+pub mod ci;
 pub mod database;
 pub mod docker;
-pub mod ci;
 
-use std::error::Error;
 use std::collections::HashMap;
+use std::error::Error;
 
 /// Extended project context for plugins that adds fields needed for file generation
 pub struct ProjectContext {
@@ -30,31 +30,33 @@ impl ProjectContext {
             examples: HashMap::new(),
         }
     }
-    
+
     pub fn add_dependency(&mut self, name: &str, version: &str) {
-        self.dependencies.insert(name.to_string(), version.to_string());
+        self.dependencies
+            .insert(name.to_string(), version.to_string());
     }
-    
+
     pub fn add_dev_dependency(&mut self, name: &str, version: &str) {
-        self.dev_dependencies.insert(name.to_string(), version.to_string());
+        self.dev_dependencies
+            .insert(name.to_string(), version.to_string());
     }
-    
+
     pub fn add_template_file(&mut self, path: &str, content: String) {
         self.template_files.insert(path.to_string(), content);
     }
-    
+
     pub fn create_directory(&mut self, path: &str) {
         self.directories.push(path.to_string());
     }
-    
+
     pub fn add_to_gitignore(&mut self, entry: &str) {
         self.gitignore_entries.push(entry.to_string());
     }
-    
+
     pub fn add_to_readme(&mut self, section: &str) {
         self.readme_sections.push(section.to_string());
     }
-    
+
     pub fn add_example(&mut self, name: &str, code: String) {
         self.examples.insert(name.to_string(), code);
     }
@@ -62,9 +64,9 @@ impl ProjectContext {
 
 pub trait Plugin {
     fn name(&self) -> &str;
-    
+
     fn configure(&self, context: &mut ProjectContext) -> Result<(), Box<dyn Error>>;
-    
+
     fn post_configure(&self, _context: &ProjectContext) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
@@ -80,29 +82,29 @@ impl PluginManager {
             plugins: Vec::new(),
         }
     }
-    
+
     pub fn register(&mut self, plugin: Box<dyn Plugin>) {
         self.plugins.push(plugin);
     }
-    
+
     pub fn len(&self) -> usize {
         self.plugins.len()
     }
-    
+
     pub fn is_empty(&self) -> bool {
         self.plugins.is_empty()
     }
-    
+
     pub fn configure_all(&self, context: &mut ProjectContext) -> Result<(), Box<dyn Error>> {
         for plugin in &self.plugins {
             println!("Configuring plugin: {}", plugin.name());
             plugin.configure(context)?;
         }
-        
+
         for plugin in &self.plugins {
             plugin.post_configure(context)?;
         }
-        
+
         Ok(())
     }
 }

--- a/src/forge.rs
+++ b/src/forge.rs
@@ -1,14 +1,14 @@
-use crate::{ProjectType, Generator, ProjectConfig, Config};
-use anyhow::{anyhow, Result};
+use crate::{Config, Generator, ProjectConfig, ProjectType};
+use anyhow::{anyhow, Ok, Result};
 use colored::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use inquire::{Confirm, MultiSelect, Select, Text};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::fs;
 
 /// Context for project creation containing all user inputs
 #[derive(Debug, Clone, Serialize)]
@@ -20,6 +20,8 @@ pub struct ProjectContext {
     pub description: Option<String>,
     pub license: Option<String>,
     pub edition: String,
+    pub target: Option<String>,
+    pub esp32_chip: Option<String>,
 }
 
 impl ProjectContext {
@@ -27,9 +29,12 @@ impl ProjectContext {
     pub fn build_template_context(&self) -> HashMap<String, serde_json::Value> {
         let mut context = HashMap::new();
         context.insert("project_name".to_string(), serde_json::json!(self.name));
-        context.insert("project_type".to_string(), serde_json::json!(self.project_type.to_string()));
+        context.insert(
+            "project_type".to_string(),
+            serde_json::json!(self.project_type.to_string()),
+        );
         context.insert("features".to_string(), serde_json::json!(self.features));
-        
+
         if let Some(author) = &self.author {
             context.insert("author".to_string(), serde_json::json!(author));
         }
@@ -39,7 +44,15 @@ impl ProjectContext {
         if let Some(license) = &self.license {
             context.insert("license".to_string(), serde_json::json!(license));
         }
-        
+
+        if let Some(target) = &self.target {
+            context.insert("target".to_string(), serde_json::json!(target));
+        }
+
+        if let Some(esp32_chip) = &self.esp32_chip {
+            context.insert("esp32_chip".to_string(), serde_json::json!(esp32_chip));
+        }
+
         context.insert("edition".to_string(), serde_json::json!(self.edition));
         context
     }
@@ -52,6 +65,8 @@ impl ProjectContext {
             author: self.author.clone().unwrap_or_else(|| "Unknown".to_string()),
             description: self.description.clone(),
             features: self.features.clone(),
+            target: self.target.clone(),
+            esp32_chip: self.esp32_chip.clone(),
         }
     }
 }
@@ -104,8 +119,9 @@ impl ForgeConfig {
 
     /// Get the default configuration file path
     pub fn config_path() -> Result<PathBuf> {
-        let config_dir = dirs::config_dir()
-            .ok_or_else(|| anyhow!("Could not find config directory"))?;
+        let config_dir =
+            dirs::config_dir().ok_or_else(|| anyhow!("Could not find config directory"))?;
+
         Ok(config_dir.join("cargo-forge").join("config.json"))
     }
 
@@ -132,15 +148,14 @@ impl Forge {
     }
 
     pub fn run(&self) -> Result<()> {
-        println!("{}", "🔨 Welcome to Cargo-Forge!".bright_cyan().bold());
-        println!("{}", "Let's create your new Rust project.\n".bright_white());
+        println!("{}", "Let's create your new Rust project.".bright_white());
 
         // Collect project context through interactive prompts
         let context = self.collect_project_context()?;
-        
+
         // Create project with progress indicators
         self.create_project(context)?;
-        
+
         Ok(())
     }
 
@@ -149,7 +164,7 @@ impl Forge {
         // In production, use run() for the full interactive experience
         let mut input = String::new();
         _reader.read_to_string(&mut input)?;
-        
+
         // Parse the input (simplified for testing)
         let lines: Vec<&str> = input.trim().split('\n').collect();
         if lines.len() >= 2 {
@@ -157,7 +172,7 @@ impl Forge {
             let project_path = self.base_path.join(project_name);
             std::fs::create_dir_all(&project_path)?;
         }
-        
+
         Ok(())
     }
 
@@ -165,26 +180,32 @@ impl Forge {
     fn collect_project_context(&self) -> Result<ProjectContext> {
         // Make a mutable copy of config for saving choices
         let mut config = self.config.clone();
-        
+
         // Project name with validation
         let name = self.prompt_project_name()?;
-        
+
         // Project type selection
         let project_type = self.prompt_project_type_interactive()?;
-        
+
+        let (target, esp32_chip) = if project_type == ProjectType::Embedded {
+            self.prompt_embedded_target()?
+        } else {
+            (None, None)
+        };
+
         // Feature selection based on project type
-        let features = self.prompt_features(&project_type)?;
-        
+        let features = self.prompt_features(&project_type, target.clone())?;
+
         // Optional fields with config defaults
         let author = self.prompt_author_with_config(&mut config)?;
         let description = self.prompt_optional_field("Description", "A new Rust project")?;
         let license = self.prompt_license_with_config(&mut config)?;
-        
+
         // Save config if any choices were remembered
         if config.remember_choices {
             let _ = config.save_to_home(); // Ignore errors for user experience
         }
-        
+
         Ok(ProjectContext {
             name,
             project_type,
@@ -193,51 +214,115 @@ impl Forge {
             description,
             license,
             edition: "2021".to_string(),
+            target,
+            esp32_chip,
         })
+    }
+
+    /// Prompt for Embedded Target selection
+    fn prompt_embedded_target(&self) -> Result<(Option<String>, Option<String>)> {
+        let targets = vec![
+            "Cortex-M (ARM Microcontrollers)",
+            "ESP32 (Espressif Microcontrollers)",
+        ];
+
+        let target = Select::new("Embedded Target : ", targets).prompt()?;
+
+        if target.starts_with("ESP32") {
+            let chip = crate::external_generators::interactive_esp32_chip_selection()?;
+            Ok((Some("esp32".to_string()), Some(chip)))
+        } else {
+            Ok((None, None))
+        }
     }
 
     /// Prompt for project name with validation
     fn prompt_project_name(&self) -> Result<String> {
-        let name = Text::new("Project name:")
-            .with_placeholder("my-awesome-project")
-            .with_validator(|input: &str| {
-                if input.is_empty() {
-                    Ok(inquire::validator::Validation::Invalid("Project name cannot be empty".into()))
-                } else if input.len() > 64 {
-                    Ok(inquire::validator::Validation::Invalid("Project name is too long (max 64 characters)".into()))
-                } else if input != input.to_lowercase() {
-                    Ok(inquire::validator::Validation::Invalid("Project name must be lowercase".into()))
-                } else if input.starts_with(|c: char| c.is_numeric()) {
-                    Ok(inquire::validator::Validation::Invalid("Project name cannot start with a number".into()))
-                } else if !input.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
-                    Ok(inquire::validator::Validation::Invalid("Project name can only contain letters, numbers, '-', and '_'".into()))
-                } else {
-                    Ok(inquire::validator::Validation::Valid)
-                }
-            })
-            .with_help_message("Must be a valid Rust package name (lowercase, no spaces)")
-            .prompt()?;
+        loop {
+            let name = Text::new("Project name:")
+                .with_placeholder("my-awesome-project")
+                .with_help_message("Must be a valid Rust package name (lowercase, no spaces)")
+                .prompt()?;
 
-        Ok(name)
+            // Validate manually
+            if name.is_empty() {
+                eprintln!("{}", "❌ Project name cannot be empty".red());
+                continue;
+            }
+            if name.len() > 64 {
+                eprintln!(
+                    "{}",
+                    "❌ Project name is too long (max 64 characters)".red()
+                );
+                continue;
+            }
+            if name != name.to_lowercase() {
+                eprintln!("{}", "❌ Project name must be lowercase".red());
+                continue;
+            }
+            if name.starts_with(|c: char| c.is_numeric()) {
+                eprintln!("{}", "❌ Project name cannot start with a number".red());
+                continue;
+            }
+            if !name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+            {
+                eprintln!(
+                    "{}",
+                    "❌ Project name can only contain letters, numbers, '-', and '_'".red()
+                );
+                continue;
+            }
+
+            return Ok(name);
+        }
     }
 
     /// Interactive project type selection
     fn prompt_project_type_interactive(&self) -> Result<ProjectType> {
         let options = vec![
-            ("API Server", "RESTful API with Axum framework", ProjectType::ApiServer),
-            ("CLI Tool", "Command-line application with Clap", ProjectType::CliTool),
+            (
+                "API Server",
+                "RESTful API with Axum framework",
+                ProjectType::ApiServer,
+            ),
+            (
+                "CLI Tool",
+                "Command-line application with Clap",
+                ProjectType::CliTool,
+            ),
             ("Library", "Reusable Rust library", ProjectType::Library),
             ("WASM App", "WebAssembly application", ProjectType::WasmApp),
-            ("Game Engine", "Game development with Bevy", ProjectType::GameEngine),
-            ("Embedded", "No-std embedded development", ProjectType::Embedded),
-            ("Workspace", "Multi-crate workspace project", ProjectType::Workspace),
+            (
+                "Game Engine",
+                "Game development with Bevy",
+                ProjectType::GameEngine,
+            ),
+            (
+                "Embedded",
+                "No-std embedded development",
+                ProjectType::Embedded,
+            ),
+            (
+                "Workspace",
+                "Multi-crate workspace project",
+                ProjectType::Workspace,
+            ),
         ];
 
-        let selection = Select::new("Project type:", options.iter().map(|(name, desc, _)| format!("{} - {}", name, desc)).collect())
-            .with_help_message("Choose the type of project you want to create")
-            .prompt()?;
+        let selection = Select::new(
+            "Project type:",
+            options
+                .iter()
+                .map(|(name, desc, _)| format!("{} - {}", name, desc))
+                .collect(),
+        )
+        .with_help_message("Choose the type of project you want to create")
+        .prompt()?;
 
-        let project_type = options.iter()
+        let project_type = options
+            .iter()
             .find(|(name, desc, _)| format!("{} - {}", name, desc) == selection)
             .map(|(_, _, pt)| *pt)
             .ok_or_else(|| anyhow!("Invalid project type selection"))?;
@@ -246,7 +331,11 @@ impl Forge {
     }
 
     /// Prompt for features based on project type
-    fn prompt_features(&self, project_type: &ProjectType) -> Result<Vec<String>> {
+    fn prompt_features(
+        &self,
+        project_type: &ProjectType,
+        target: Option<String>,
+    ) -> Result<Vec<String>> {
         let available_features = match project_type {
             ProjectType::ApiServer => vec![
                 ("axum", "Web framework", true),
@@ -287,17 +376,28 @@ impl Forge {
                 ("physics", "Physics simulation", false),
                 ("ui", "UI framework", false),
             ],
-            ProjectType::Embedded => vec![
-                ("cortex-m", "ARM Cortex-M support", true),
-                ("cortex-m-rt", "Runtime support", true),
-                ("panic-halt", "Panic handler", true),
-                ("stm32f4", "STM32F4 HAL", false),
-                ("stm32f1", "STM32F1 HAL", false),
-                ("rp2040", "Raspberry Pi Pico", false),
-                ("esp32", "ESP32 HAL", false),
-                ("rtt", "Real-time transfer", false),
-                ("semihosting", "Semihosting debug", false),
-            ],
+            ProjectType::Embedded => {
+                // Handle different Embedded Targets
+                match target {
+                    Some(target_str) if target_str == "esp32" => {
+                        return Ok(Vec::new());
+                    }
+                    _ => {
+                        // Show Cortex-M specific features
+                        vec![
+                            ("cortex-m", "ARM Cortex-M support", true),
+                            ("cortex-m-rt", "Runtime support", true),
+                            ("panic-halt", "Halt on panic", true),
+                            ("panic-rtt", "RTT panic messages", false),
+                            ("rtt", "Real-time transfer debugging", false),
+                            ("semihosting", "Semihosting debug output", false),
+                            ("stm32f4", "STM32F4 HAL", false),
+                            ("stm32f1", "STM32F1 HAL", false),
+                            ("rp2040", "Raspberry Pi Pico support", false),
+                        ]
+                    }
+                }
+            }
             ProjectType::Workspace => vec![
                 ("tokio", "Async runtime", true),
                 ("serde", "Serialization", true),
@@ -309,16 +409,19 @@ impl Forge {
             ],
         };
 
-        let _default_features: Vec<String> = available_features.iter()
+        let _default_features: Vec<String> = available_features
+            .iter()
             .filter(|(_, _, default)| *default)
             .map(|(name, _, _)| name.to_string())
             .collect();
 
-        let options: Vec<String> = available_features.iter()
+        let options: Vec<String> = available_features
+            .iter()
             .map(|(name, desc, _)| format!("{} - {}", name, desc))
             .collect();
 
-        let default_indices: Vec<usize> = available_features.iter()
+        let default_indices: Vec<usize> = available_features
+            .iter()
             .enumerate()
             .filter(|(_, (_, _, default))| *default)
             .map(|(i, _)| i)
@@ -329,9 +432,11 @@ impl Forge {
             .with_help_message("Space to select/deselect, Enter to confirm")
             .prompt()?;
 
-        let features: Vec<String> = selections.iter()
+        let features: Vec<String> = selections
+            .iter()
             .filter_map(|selection| {
-                available_features.iter()
+                available_features
+                    .iter()
                     .find(|(name, desc, _)| format!("{} - {}", name, desc) == *selection)
                     .map(|(name, _, _)| name.to_string())
             })
@@ -363,10 +468,16 @@ impl Forge {
             .prompt()?;
 
         if include_license {
-            let licenses = vec!["MIT", "Apache-2.0", "GPL-3.0", "BSD-3-Clause", "Unlicense", "Other"];
-            let license = Select::new("License:", licenses)
-                .prompt()?;
-            
+            let licenses = vec![
+                "MIT",
+                "Apache-2.0",
+                "GPL-3.0",
+                "BSD-3-Clause",
+                "Unlicense",
+                "Other",
+            ];
+            let license = Select::new("License:", licenses).prompt()?;
+
             if license == "Other" {
                 let custom = Text::new("Custom license:")
                     .with_placeholder("AGPL-3.0")
@@ -384,16 +495,14 @@ impl Forge {
     fn prompt_author_with_config(&self, config: &mut Config) -> Result<Option<String>> {
         // Use config default if available
         let default_author = config.default_author.as_deref();
-        
+
         let include = if default_author.is_some() {
             // If we have a config default, ask if they want to use it or change it
-            let use_default = Confirm::new(&format!(
-                "Use saved author '{}'?", 
-                default_author.unwrap()
-            ))
-            .with_default(true)
-            .prompt()?;
-            
+            let use_default =
+                Confirm::new(&format!("Use saved author '{}'?", default_author.unwrap()))
+                    .with_default(true)
+                    .prompt()?;
+
             if use_default {
                 return Ok(config.default_author.clone());
             } else {
@@ -410,18 +519,18 @@ impl Forge {
             let author = Text::new("Author:")
                 .with_placeholder("your-name")
                 .prompt()?;
-            
+
             // Ask if they want to remember this choice
             if config.remember_choices {
                 let remember = Confirm::new("Remember this choice for future projects?")
                     .with_default(true)
                     .prompt()?;
-                
+
                 if remember {
                     config.remember_choice("author", &author);
                 }
             }
-            
+
             Ok(Some(author))
         } else {
             Ok(None)
@@ -432,16 +541,16 @@ impl Forge {
     fn prompt_license_with_config(&self, config: &mut Config) -> Result<Option<String>> {
         // Use config default if available
         let default_license = config.default_license.as_deref();
-        
+
         let include_license = if default_license.is_some() {
             // If we have a config default, ask if they want to use it or change it
             let use_default = Confirm::new(&format!(
-                "Use saved license '{}'?", 
+                "Use saved license '{}'?",
                 default_license.unwrap()
             ))
             .with_default(true)
             .prompt()?;
-            
+
             if use_default {
                 return Ok(config.default_license.clone());
             } else {
@@ -455,10 +564,16 @@ impl Forge {
         };
 
         if include_license {
-            let licenses = vec!["MIT", "Apache-2.0", "GPL-3.0", "BSD-3-Clause", "Unlicense", "Other"];
-            let license = Select::new("License:", licenses)
-                .prompt()?;
-            
+            let licenses = vec![
+                "MIT",
+                "Apache-2.0",
+                "GPL-3.0",
+                "BSD-3-Clause",
+                "Unlicense",
+                "Other",
+            ];
+            let license = Select::new("License:", licenses).prompt()?;
+
             let final_license = if license == "Other" {
                 let custom = Text::new("Custom license:")
                     .with_placeholder("AGPL-3.0")
@@ -467,18 +582,18 @@ impl Forge {
             } else {
                 license.to_string()
             };
-            
+
             // Ask if they want to remember this choice
             if config.remember_choices {
                 let remember = Confirm::new("Remember this choice for future projects?")
                     .with_default(true)
                     .prompt()?;
-                
+
                 if remember {
                     config.remember_choice("license", &final_license);
                 }
             }
-            
+
             Ok(Some(final_license))
         } else {
             Ok(None)
@@ -487,58 +602,101 @@ impl Forge {
 
     /// Create the project with progress indicators
     fn create_project(&self, context: ProjectContext) -> Result<()> {
-        let project_path = self.base_path.join(&context.name);
-        
-        // Check if directory already exists
-        if project_path.exists() {
-            return Err(anyhow!("Project directory '{}' already exists", context.name));
+        // Special handling for ESP32 projects - don't create directory structure first
+        if let Some(target) = &context.target {
+            if target == "esp32" {
+                println!("{}", "🔨 Creating your ESP32 project...".bright_yellow());
+
+                let pb = ProgressBar::new(100);
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template("{prefix:.bold.dim} {bar:40.cyan/blue} {percent}% {msg}")
+                        .unwrap()
+                        .progress_chars("█▉▊▋▌▍▎▏ "),
+                );
+                pb.set_prefix("Progress");
+
+                pb.set_message("Generating ESP32 project files...");
+                pb.set_position(40);
+
+                // For ESP32, use parent directory and let esp-generate create the project directory
+                let config = context.to_project_config();
+                let generator = Generator::new();
+                generator.generate(&config, &self.base_path)?; // Use base_path, not project_path
+
+                pb.set_position(100);
+                pb.finish_and_clear();
+
+                println!(
+                    "{} {}",
+                    "✅".bright_green().bold(),
+                    "ESP32 project created successfully!".bright_green()
+                );
+                self.show_next_steps(&context, false)?;
+                return Ok(());
+            }
         }
 
-        println!("\n{}", "Creating your project...".bright_yellow());
-        
+        // For non-ESP32 projects, continue with normal flow
+        let project_path = self.base_path.join(&context.name);
+
+        // Check if directory already exists (only for non-ESP32 projects)
+        if project_path.exists() {
+            return Err(anyhow!(
+                "Project directory already exists: {}",
+                context.name
+            ));
+        }
+
+        println!("{}", "🔨 Creating your project...".bright_yellow());
+
         // Progress bar for project generation
         let pb = ProgressBar::new(100);
-        pb.set_style(ProgressStyle::default_bar()
-            .template("{prefix:.bold.dim} {bar:40.cyan/blue} {percent}% {msg}")
-            .unwrap()
-            .progress_chars("##-"));
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{prefix:.bold.dim} {bar:40.cyan/blue} {percent}% {msg}")
+                .unwrap()
+                .progress_chars("█▉▊▋▌▍▎▏ "),
+        );
         pb.set_prefix("Progress");
-        
+
         // Initialize project structure
         pb.set_message("Creating project directory...");
         std::fs::create_dir_all(&project_path)?;
         pb.set_position(20);
         std::thread::sleep(Duration::from_millis(100));
-        
+
         // Generate project using generator
         pb.set_message("Generating project files...");
         let config = context.to_project_config();
         let generator = Generator::new();
-        
+
         // Simulate progress during generation
         pb.set_position(40);
         std::thread::sleep(Duration::from_millis(100));
-        
+
         generator.generate(&config, &project_path)?;
-        
         pb.set_position(80);
+
         pb.set_message("Finalizing project setup...");
         std::thread::sleep(Duration::from_millis(100));
-        
         pb.set_position(100);
         pb.finish_and_clear();
-        
+
         // Enhanced success message
-        println!("\n{} {}", "✓".bright_green().bold(), "Project created successfully!".bright_green());
+        println!(
+            "{} {}",
+            "✅".bright_green().bold(),
+            "Project created successfully!".bright_green()
+        );
         self.show_next_steps(&context, false)?;
-        
         Ok(())
     }
 
     pub fn prompt_project_type<R: Read>(&self, reader: &mut R) -> Result<ProjectType> {
         let mut input = String::new();
         reader.read_to_string(&mut input)?;
-        
+
         let choice = input.trim();
         match choice {
             "1" => Ok(ProjectType::ApiServer),
@@ -553,70 +711,79 @@ impl Forge {
         if name.is_empty() {
             return Err(anyhow!("Project name cannot be empty"));
         }
-        
+
         // Check length
         if name.len() > 64 {
             return Err(anyhow!("Project name is too long (max 64 characters)"));
         }
-        
+
         // Check for reserved names
-        let reserved_names = ["test", "main", "build", "cargo", "rust", "src", "target", "bin", "lib"];
+        let reserved_names = [
+            "test", "main", "build", "cargo", "rust", "src", "target", "bin", "lib",
+        ];
         if reserved_names.contains(&name) {
             return Err(anyhow!("'{}' is a reserved name", name));
         }
-        
+
         // Check for invalid characters and patterns
         if name.contains(' ') {
             return Err(anyhow!("Project name cannot contain spaces"));
         }
-        
+
         if name.contains('/') || name.contains('\\') {
             return Err(anyhow!("Project name cannot contain slashes"));
         }
-        
+
         // Must be lowercase
         if name != name.to_lowercase() {
             return Err(anyhow!("Project name must be lowercase"));
         }
-        
+
         // Cannot start with a number
         if name.starts_with(|c: char| c.is_numeric()) {
             return Err(anyhow!("Project name cannot start with a number"));
         }
-        
+
         // Cannot start or end with dash/underscore
         if name.starts_with('-') || name.starts_with('_') {
             return Err(anyhow!("Project name cannot start with '-' or '_'"));
         }
-        
+
         if name.ends_with('-') || name.ends_with('_') {
             return Err(anyhow!("Project name cannot end with '-' or '_'"));
         }
-        
+
         // Check for valid characters (alphanumeric, dash, underscore)
-        if !name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
-            return Err(anyhow!("Project name can only contain letters, numbers, '-', and '_'"));
+        if !name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(anyhow!(
+                "Project name can only contain letters, numbers, '-', and '_'"
+            ));
         }
-        
+
         // Check for double dashes or underscores
         if name.contains("--") || name.contains("__") {
-            return Err(anyhow!("Project name cannot contain consecutive dashes or underscores"));
+            return Err(anyhow!(
+                "Project name cannot contain consecutive dashes or underscores"
+            ));
         }
-        
+
         Ok(())
     }
 
     /// Run in non-interactive mode with defaults
     pub fn run_non_interactive(
-        &self, 
-        name: Option<String>, 
-        project_type: Option<String>, 
-        author: Option<String>, 
+        &self,
+        name: Option<String>,
+        project_type: Option<String>,
+        author: Option<String>,
         description: Option<String>,
-        from_config: Option<PathBuf>
+        from_config: Option<PathBuf>,
     ) -> Result<()> {
         println!("{}", "🤖 Non-interactive mode".bright_blue().bold());
-        
+
         let config = if let Some(config_path) = from_config {
             ForgeConfig::load_from(config_path)?
         } else {
@@ -624,21 +791,27 @@ impl Forge {
         };
 
         let project_name = name.unwrap_or_else(|| "my-project".to_string());
-        
+
         // Validate project name before doing anything else
         self.validate_project_name(&project_name)?;
-        
+
         let project_type_str = project_type.unwrap_or_else(|| "cli-tool".to_string());
         let project_type = self.parse_project_type(&project_type_str)?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
-            features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+            features: config
+                .default_features
+                .get(&project_type_str)
+                .cloned()
+                .unwrap_or_default(),
             author: author.or(config.default_author),
             description,
             license: config.default_license,
             edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+            target: None,
+            esp32_chip: None,
         };
 
         self.create_project(context)?;
@@ -651,16 +824,16 @@ impl Forge {
         name: Option<String>,
         project_type: Option<String>,
         author: Option<String>,
-        description: Option<String>
+        description: Option<String>,
     ) -> Result<()> {
         let project_name = name.ok_or_else(|| anyhow!("Project name is required"))?;
-        
+
         // Validate project name before doing anything else
         self.validate_project_name(&project_name)?;
-        
+
         let project_type_str = project_type.ok_or_else(|| anyhow!("Project type is required"))?;
         let project_type = self.parse_project_type(&project_type_str)?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
@@ -669,6 +842,8 @@ impl Forge {
             description,
             license: Some("MIT".to_string()),
             edition: "2021".to_string(),
+            target: None,
+            esp32_chip: None,
         };
 
         self.create_project(context)?;
@@ -682,29 +857,36 @@ impl Forge {
         name: Option<String>,
         project_type: Option<String>,
         author: Option<String>,
-        description: Option<String>
+        description: Option<String>,
     ) -> Result<()> {
         println!("{}", "📁 Loading configuration...".bright_cyan());
-        
+
         let config = ForgeConfig::load_from(config_path)?;
-        
+
         let project_name = name.unwrap_or_else(|| "my-project".to_string());
-        
+
         // Validate project name before doing anything else
         self.validate_project_name(&project_name)?;
-        
-        let project_type_str = project_type.or_else(|| config.preferred_project_types.first().cloned())
+
+        let project_type_str = project_type
+            .or_else(|| config.preferred_project_types.first().cloned())
             .unwrap_or_else(|| "cli-tool".to_string());
         let project_type = self.parse_project_type(&project_type_str)?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
-            features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+            features: config
+                .default_features
+                .get(&project_type_str)
+                .cloned()
+                .unwrap_or_default(),
             author: author.or(config.default_author),
             description,
             license: config.default_license,
             edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+            target: None,
+            esp32_chip: None,
         };
 
         self.create_project(context)?;
@@ -719,7 +901,7 @@ impl Forge {
         author: Option<String>,
         description: Option<String>,
         non_interactive: bool,
-        from_config: Option<PathBuf>
+        from_config: Option<PathBuf>,
     ) -> Result<()> {
         if non_interactive {
             let config = if let Some(config_path) = from_config {
@@ -729,21 +911,27 @@ impl Forge {
             };
 
             let project_name = name.unwrap_or_else(|| "my-project".to_string());
-            
+
             // Validate project name before doing anything else
             self.validate_project_name(&project_name)?;
-            
+
             let project_type_str = project_type.unwrap_or_else(|| "cli-tool".to_string());
             let project_type = self.parse_project_type(&project_type_str)?;
-            
+
             let context = ProjectContext {
                 name: project_name,
                 project_type,
-                features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+                features: config
+                    .default_features
+                    .get(&project_type_str)
+                    .cloned()
+                    .unwrap_or_default(),
                 author: author.or(config.default_author),
                 description,
                 license: config.default_license,
                 edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+                target: None,
+                esp32_chip: None,
             };
 
             self.preview_project(&context)
@@ -757,10 +945,15 @@ impl Forge {
     pub fn run_init_non_interactive(
         &self,
         project_type: Option<String>,
-        from_config: Option<PathBuf>
+        from_config: Option<PathBuf>,
     ) -> Result<()> {
-        println!("{}", "🤖 Initializing in current directory (non-interactive)".bright_blue().bold());
-        
+        println!(
+            "{}",
+            "🤖 Initializing in current directory (non-interactive)"
+                .bright_blue()
+                .bold()
+        );
+
         let config = if let Some(config_path) = from_config {
             ForgeConfig::load_from(config_path)?
         } else {
@@ -768,22 +961,29 @@ impl Forge {
         };
 
         let current_dir = std::env::current_dir()?;
-        let project_name = current_dir.file_name()
+        let project_name = current_dir
+            .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("my-project")
             .to_string();
 
         let project_type_str = project_type.unwrap_or_else(|| "cli-tool".to_string());
         let project_type = self.parse_project_type(&project_type_str)?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
-            features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+            features: config
+                .default_features
+                .get(&project_type_str)
+                .cloned()
+                .unwrap_or_default(),
             author: config.default_author,
             description: None,
             license: config.default_license,
             edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+            target: None,
+            esp32_chip: None,
         };
 
         self.init_project_in_current_dir(context)?;
@@ -792,10 +992,16 @@ impl Forge {
 
     /// Initialize with regular interactive prompts
     pub fn run_init(&self, project_type: Option<String>) -> Result<()> {
-        println!("{}", "🔨 Initializing project in current directory".bright_cyan().bold());
-        
+        println!(
+            "{}",
+            "🔨 Initializing project in current directory"
+                .bright_cyan()
+                .bold()
+        );
+
         let current_dir = std::env::current_dir()?;
-        let project_name = current_dir.file_name()
+        let project_name = current_dir
+            .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("my-project")
             .to_string();
@@ -805,12 +1011,12 @@ impl Forge {
         } else {
             self.prompt_project_type_interactive()?
         };
-        
-        let features = self.prompt_features(&project_type)?;
+
+        let features = self.prompt_features(&project_type, None)?;
         let author = self.prompt_optional_field("Author", "your-name")?;
         let description = self.prompt_optional_field("Description", "A new Rust project")?;
         let license = self.prompt_license()?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
@@ -819,6 +1025,8 @@ impl Forge {
             description,
             license,
             edition: "2021".to_string(),
+            target: None,
+            esp32_chip: None,
         };
 
         self.init_project_in_current_dir(context)?;
@@ -826,29 +1034,41 @@ impl Forge {
     }
 
     /// Initialize from config file
-    pub fn run_init_from_config(&self, config_path: PathBuf, project_type: Option<String>) -> Result<()> {
+    pub fn run_init_from_config(
+        &self,
+        config_path: PathBuf,
+        project_type: Option<String>,
+    ) -> Result<()> {
         println!("{}", "📁 Initializing from configuration...".bright_cyan());
-        
+
         let config = ForgeConfig::load_from(config_path)?;
-        
+
         let current_dir = std::env::current_dir()?;
-        let project_name = current_dir.file_name()
+        let project_name = current_dir
+            .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("my-project")
             .to_string();
 
-        let project_type_str = project_type.or_else(|| config.preferred_project_types.first().cloned())
+        let project_type_str = project_type
+            .or_else(|| config.preferred_project_types.first().cloned())
             .unwrap_or_else(|| "cli-tool".to_string());
         let project_type = self.parse_project_type(&project_type_str)?;
-        
+
         let context = ProjectContext {
             name: project_name,
             project_type,
-            features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+            features: config
+                .default_features
+                .get(&project_type_str)
+                .cloned()
+                .unwrap_or_default(),
             author: config.default_author,
             description: None,
             license: config.default_license,
             edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+            target: None,
+            esp32_chip: None,
         };
 
         self.init_project_in_current_dir(context)?;
@@ -860,10 +1080,11 @@ impl Forge {
         &self,
         project_type: Option<String>,
         non_interactive: bool,
-        from_config: Option<PathBuf>
+        from_config: Option<PathBuf>,
     ) -> Result<()> {
         let current_dir = std::env::current_dir()?;
-        let project_name = current_dir.file_name()
+        let project_name = current_dir
+            .file_name()
             .and_then(|name| name.to_str())
             .unwrap_or("my-project")
             .to_string();
@@ -877,15 +1098,21 @@ impl Forge {
 
             let project_type_str = project_type.unwrap_or_else(|| "cli-tool".to_string());
             let project_type = self.parse_project_type(&project_type_str)?;
-            
+
             let context = ProjectContext {
                 name: project_name,
                 project_type,
-                features: config.default_features.get(&project_type_str).cloned().unwrap_or_default(),
+                features: config
+                    .default_features
+                    .get(&project_type_str)
+                    .cloned()
+                    .unwrap_or_default(),
                 author: config.default_author,
                 description: None,
                 license: config.default_license,
                 edition: config.edition.unwrap_or_else(|| "2021".to_string()),
+                target: None,
+                esp32_chip: None,
             };
 
             self.preview_init(&context)
@@ -895,12 +1122,12 @@ impl Forge {
             } else {
                 self.prompt_project_type_interactive()?
             };
-            
-            let features = self.prompt_features(&project_type)?;
+
+            let features = self.prompt_features(&project_type, None)?;
             let author = self.prompt_optional_field("Author", "your-name")?;
             let description = self.prompt_optional_field("Description", "A new Rust project")?;
             let license = self.prompt_license()?;
-            
+
             let context = ProjectContext {
                 name: project_name,
                 project_type,
@@ -909,6 +1136,8 @@ impl Forge {
                 description,
                 license,
                 edition: "2021".to_string(),
+                target: None,
+                esp32_chip: None,
             };
 
             self.preview_init(&context)
@@ -933,36 +1162,63 @@ impl Forge {
     fn preview_project(&self, context: &ProjectContext) -> Result<()> {
         println!("\n{}", "📋 Project Preview".bright_white().bold());
         println!("{}", "─".repeat(50).bright_black());
-        
-        println!("{} {}", "📦 Name:".bright_cyan(), context.name.bright_white());
-        println!("{} {}", "🏗️  Type:".bright_cyan(), context.project_type.to_string().bright_white());
-        
+
+        println!(
+            "{} {}",
+            "📦 Name:".bright_cyan(),
+            context.name.bright_white()
+        );
+        println!(
+            "{} {}",
+            "🏗️  Type:".bright_cyan(),
+            context.project_type.to_string().bright_white()
+        );
+
         if let Some(author) = &context.author {
             println!("{} {}", "👤 Author:".bright_cyan(), author.bright_white());
         }
-        
+
         if let Some(description) = &context.description {
-            println!("{} {}", "📝 Description:".bright_cyan(), description.bright_white());
+            println!(
+                "{} {}",
+                "📝 Description:".bright_cyan(),
+                description.bright_white()
+            );
         }
-        
+
         if let Some(license) = &context.license {
-            println!("{} {}", "⚖️  License:".bright_cyan(), license.bright_white());
+            println!(
+                "{} {}",
+                "⚖️  License:".bright_cyan(),
+                license.bright_white()
+            );
         }
-        
-        println!("{} {}", "📅 Edition:".bright_cyan(), context.edition.bright_white());
-        
+
+        println!(
+            "{} {}",
+            "📅 Edition:".bright_cyan(),
+            context.edition.bright_white()
+        );
+
         if !context.features.is_empty() {
-            println!("{} {}", "🎯 Features:".bright_cyan(), context.features.join(", ").bright_white());
+            println!(
+                "{} {}",
+                "🎯 Features:".bright_cyan(),
+                context.features.join(", ").bright_white()
+            );
         }
-        
+
         println!("\n{}", "📁 Directory Structure:".bright_white().bold());
         self.preview_directory_structure(context);
-        
-        println!("\n{}", "Next steps (if this were real):".bright_green().bold());
+
+        println!(
+            "\n{}",
+            "Next steps (if this were real):".bright_green().bold()
+        );
         println!("  {} cd {}", "→".bright_cyan(), context.name);
         println!("  {} cargo build", "→".bright_cyan());
         println!("  {} cargo run\n", "→".bright_cyan());
-        
+
         Ok(())
     }
 
@@ -970,30 +1226,53 @@ impl Forge {
     fn preview_init(&self, context: &ProjectContext) -> Result<()> {
         println!("\n{}", "📋 Initialization Preview".bright_white().bold());
         println!("{}", "─".repeat(50).bright_black());
-        
-        println!("{} {}", "📦 Name:".bright_cyan(), context.name.bright_white());
-        println!("{} {}", "🏗️  Type:".bright_cyan(), context.project_type.to_string().bright_white());
-        println!("{} {}", "📁 Location:".bright_cyan(), "Current directory".bright_white());
-        
+
+        println!(
+            "{} {}",
+            "📦 Name:".bright_cyan(),
+            context.name.bright_white()
+        );
+        println!(
+            "{} {}",
+            "🏗️  Type:".bright_cyan(),
+            context.project_type.to_string().bright_white()
+        );
+        println!(
+            "{} {}",
+            "📁 Location:".bright_cyan(),
+            "Current directory".bright_white()
+        );
+
         if let Some(author) = &context.author {
             println!("{} {}", "👤 Author:".bright_cyan(), author.bright_white());
         }
-        
+
         if let Some(license) = &context.license {
-            println!("{} {}", "⚖️  License:".bright_cyan(), license.bright_white());
+            println!(
+                "{} {}",
+                "⚖️  License:".bright_cyan(),
+                license.bright_white()
+            );
         }
-        
+
         if !context.features.is_empty() {
-            println!("{} {}", "🎯 Features:".bright_cyan(), context.features.join(", ").bright_white());
+            println!(
+                "{} {}",
+                "🎯 Features:".bright_cyan(),
+                context.features.join(", ").bright_white()
+            );
         }
-        
+
         println!("\n{}", "📁 Files to be created:".bright_white().bold());
         self.preview_directory_structure(context);
-        
-        println!("\n{}", "Next steps (if this were real):".bright_green().bold());
+
+        println!(
+            "\n{}",
+            "Next steps (if this were real):".bright_green().bold()
+        );
         println!("  {} cargo build", "→".bright_cyan());
         println!("  {} cargo run\n", "→".bright_cyan());
-        
+
         Ok(())
     }
 
@@ -1002,13 +1281,13 @@ impl Forge {
         println!("  {}/", context.name.bright_yellow());
         println!("  ├── {}", "Cargo.toml".bright_green());
         println!("  ├── {}", "README.md".bright_green());
-        
+
         if context.license.is_some() {
             println!("  ├── {}", "LICENSE".bright_green());
         }
-        
+
         println!("  ├── {}/ ", "src".bright_blue());
-        
+
         match context.project_type {
             ProjectType::Library => {
                 println!("  │   └── {}", "lib.rs".bright_green());
@@ -1017,16 +1296,16 @@ impl Forge {
                 println!("  │   └── {}", "main.rs".bright_green());
             }
         }
-        
+
         if context.features.contains(&"testing".to_string()) {
             println!("  ├── {}/ ", "tests".bright_blue());
             println!("  │   └── {}", "integration_tests.rs".bright_green());
         }
-        
+
         if context.project_type == ProjectType::WasmApp {
             println!("  └── {}", "index.html".bright_green());
         }
-        
+
         if context.project_type == ProjectType::GameEngine {
             println!("  └── {}/ ", "assets".bright_blue());
             println!("      ├── {}/ ", "models".bright_blue());
@@ -1039,29 +1318,35 @@ impl Forge {
     /// Initialize project in current directory
     fn init_project_in_current_dir(&self, context: ProjectContext) -> Result<()> {
         let current_dir = std::env::current_dir()?;
-        
+
         println!("\n{}", "Creating project files...".bright_yellow());
-        
+
         let pb = ProgressBar::new(100);
-        pb.set_style(ProgressStyle::default_bar()
-            .template("{prefix:.bold.dim} {bar:40.cyan/blue} {percent}% {msg}")
-            .unwrap()
-            .progress_chars("##-"));
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template("{prefix:.bold.dim} {bar:40.cyan/blue} {percent}% {msg}")
+                .unwrap()
+                .progress_chars("##-"),
+        );
         pb.set_prefix("Progress");
-        
+
         pb.set_message("Generating project files...");
         let config = context.to_project_config();
         let generator = Generator::new();
-        
+
         pb.set_position(50);
         generator.generate(&config, &current_dir)?;
-        
+
         pb.set_position(100);
         pb.finish_and_clear();
-        
-        println!("\n{} {}", "✓".bright_green().bold(), "Project initialized successfully!".bright_green());
+
+        println!(
+            "\n{} {}",
+            "✓".bright_green().bold(),
+            "Project initialized successfully!".bright_green()
+        );
         self.show_next_steps(&context, true)?;
-        
+
         Ok(())
     }
 
@@ -1069,28 +1354,50 @@ impl Forge {
     fn show_next_steps(&self, context: &ProjectContext, is_init: bool) -> Result<()> {
         println!("\n{}", "🎉 Project Setup Complete!".bright_green().bold());
         println!("{}", "─".repeat(50).bright_black());
-        
+
         println!("\n{}", "📋 Project Summary:".bright_white().bold());
-        println!("  {} {}", "Name:".bright_cyan(), context.name.bright_white());
-        println!("  {} {}", "Type:".bright_cyan(), context.project_type.to_string().bright_white());
+        println!(
+            "  {} {}",
+            "Name:".bright_cyan(),
+            context.name.bright_white()
+        );
+        println!(
+            "  {} {}",
+            "Type:".bright_cyan(),
+            context.project_type.to_string().bright_white()
+        );
         if !context.features.is_empty() {
-            println!("  {} {}", "Features:".bright_cyan(), context.features.join(", ").bright_white());
+            println!(
+                "  {} {}",
+                "Features:".bright_cyan(),
+                context.features.join(", ").bright_white()
+            );
         }
-        
+
         println!("\n{}", "🚀 Next Steps:".bright_white().bold());
-        
+
         if !is_init {
-            println!("  {} cd {}", "1.".bright_yellow(), context.name.bright_white());
+            println!(
+                "  {} cd {}",
+                "1.".bright_yellow(),
+                context.name.bright_white()
+            );
         }
-        
+
         let step_num = if is_init { 1 } else { 2 };
         println!("  {} cargo build", format!("{}.", step_num).bright_yellow());
-        println!("  {} cargo run", format!("{}.", step_num + 1).bright_yellow());
-        
+        println!(
+            "  {} cargo run",
+            format!("{}.", step_num + 1).bright_yellow()
+        );
+
         if context.features.contains(&"testing".to_string()) {
-            println!("  {} cargo test", format!("{}.", step_num + 2).bright_yellow());
+            println!(
+                "  {} cargo test",
+                format!("{}.", step_num + 2).bright_yellow()
+            );
         }
-        
+
         match context.project_type {
             ProjectType::ApiServer => {
                 println!("\n{}", "💡 API Server Tips:".bright_blue().bold());
@@ -1135,12 +1442,12 @@ impl Forge {
                 println!("  • Test all: cargo test");
             }
         }
-        
+
         println!("\n{}", "📚 Resources:".bright_white().bold());
         println!("  • Rust Book: https://doc.rust-lang.org/book/");
         println!("  • Cargo Guide: https://doc.rust-lang.org/cargo/");
         println!("  • Crates.io: https://crates.io/");
-        
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,16 @@
 // Re-export main types and modules
+pub use crate::config::Config;
+pub use crate::features::{Plugin, PluginManager, ProjectContext};
 pub use crate::forge::Forge;
 pub use crate::generator::{Generator, ProjectConfig};
 pub use crate::project_types::ProjectType;
 pub use crate::templates::TemplateEngine;
-pub use crate::features::{Plugin, PluginManager, ProjectContext};
-pub use crate::config::Config;
 
 // Module declarations
+pub mod config;
+pub mod external_generators;
+pub mod features;
 pub mod forge;
 pub mod generator;
 pub mod project_types;
 pub mod templates;
-pub mod features;
-pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod cli;
 
-use clap::{CommandFactory, Parser};
-use clap_complete::{generate, Generator};
 use anyhow::Result;
 use cargo_forge::Forge;
+use clap::{CommandFactory, Parser};
+use clap_complete::{generate, Generator};
 use colored::*;
 use std::io;
 
@@ -39,26 +39,38 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::New { 
-            name, 
-            project_type, 
-            author, 
-            description, 
+        Some(Commands::New {
+            name,
+            project_type,
+            author,
+            description,
             license: _,
-            non_interactive, 
-            from_config, 
-            dry_run 
+            non_interactive,
+            from_config,
+            dry_run,
         }) => {
             // Display logo unless in non-interactive mode
             if !non_interactive {
                 display_logo();
             }
-            
+
             let forge = Forge::new(".");
-            
+
             if dry_run {
-                println!("{}", "🔍 DRY RUN MODE - No files will be created".bright_yellow().bold());
-                forge.run_dry_run(name, project_type, author, description, non_interactive, from_config)?;
+                println!(
+                    "{}",
+                    "🔍 DRY RUN MODE - No files will be created"
+                        .bright_yellow()
+                        .bold()
+                );
+                forge.run_dry_run(
+                    name,
+                    project_type,
+                    author,
+                    description,
+                    non_interactive,
+                    from_config,
+                )?;
             } else if non_interactive {
                 forge.run_non_interactive(name, project_type, author, description, from_config)?;
             } else if let Some(config_path) = from_config {
@@ -70,22 +82,27 @@ fn main() -> Result<()> {
                 forge.run()?;
             }
         }
-        Some(Commands::Init { 
-            project_type, 
+        Some(Commands::Init {
+            project_type,
             author: _,
             license: _,
-            non_interactive, 
-            from_config, 
-            dry_run 
+            non_interactive,
+            from_config,
+            dry_run,
         }) => {
             if !non_interactive {
                 display_logo();
             }
-            
+
             let forge = Forge::new(".");
-            
+
             if dry_run {
-                println!("{}", "🔍 DRY RUN MODE - No files will be created".bright_yellow().bold());
+                println!(
+                    "{}",
+                    "🔍 DRY RUN MODE - No files will be created"
+                        .bright_yellow()
+                        .bold()
+                );
                 forge.run_init_dry_run(project_type, non_interactive, from_config)?;
             } else if non_interactive {
                 forge.run_init_non_interactive(project_type, from_config)?;
@@ -102,8 +119,11 @@ fn main() -> Result<()> {
         None => {
             display_logo();
             println!("{}", "🔨 Welcome to Cargo-Forge!".bright_cyan().bold());
-            println!("{}", "Starting interactive project creation...\n".bright_white());
-            
+            println!(
+                "{}",
+                "Starting interactive project creation...\n".bright_white()
+            );
+
             let forge = Forge::new(".");
             forge.run()?;
         }

--- a/src/project_types.rs
+++ b/src/project_types.rs
@@ -1,6 +1,6 @@
+use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
-use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum ProjectType {
@@ -54,6 +54,13 @@ impl ProjectType {
             ProjectType::GameEngine => vec!["bevy"],
             ProjectType::Embedded => vec!["cortex-m", "cortex-m-rt", "panic-halt"],
             ProjectType::Workspace => vec!["tokio", "serde", "anyhow"],
+        }
+    }
+
+    pub fn requires_external_generator(&self, target: Option<&str>) -> bool {
+        match self {
+            ProjectType::Embedded => target == Some("esp32"),
+            _ => false,
         }
     }
 }

--- a/src/templates/conditional.rs
+++ b/src/templates/conditional.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use tera::{Context, Tera};
 use std::collections::HashSet;
+use tera::{Context, Tera};
 
 /// Conditional template renderer that supports feature-based conditional rendering
 pub struct ConditionalRenderer {
@@ -11,43 +11,43 @@ pub struct ConditionalRenderer {
 impl ConditionalRenderer {
     pub fn new(features: Vec<String>) -> Result<Self> {
         let mut tera = Tera::default();
-        
+
         // Register custom functions for feature checking
         tera.register_function("has_feature", has_feature_function);
         tera.register_function("has_any_feature", has_any_feature_function);
         tera.register_function("has_all_features", has_all_features_function);
-        
+
         Ok(Self {
             tera,
             features: features.into_iter().collect(),
         })
     }
-    
+
     /// Add a template with a given name
     pub fn add_template(&mut self, name: &str, content: &str) -> Result<()> {
         self.tera.add_raw_template(name, content)?;
         Ok(())
     }
-    
+
     /// Render a template with feature-aware context
     pub fn render(&self, template_name: &str, mut context: Context) -> Result<String> {
         // Add features to the context
         context.insert("features", &self.features);
-        
+
         // Add feature checking helpers
         for feature in &self.features {
             context.insert(&format!("has_{}", feature), &true);
         }
-        
+
         let rendered = self.tera.render(template_name, &context)?;
         Ok(rendered)
     }
-    
+
     /// Check if a specific feature is enabled
     pub fn has_feature(&self, feature: &str) -> bool {
         self.features.contains(feature)
     }
-    
+
     /// Get all enabled features
     pub fn get_features(&self) -> Vec<String> {
         self.features.iter().cloned().collect()
@@ -55,36 +55,48 @@ impl ConditionalRenderer {
 }
 
 /// Tera function to check if a feature is enabled
-fn has_feature_function(args: &HashMap<String, serde_json::Value>) -> tera::Result<serde_json::Value> {
-    let feature = args.get("feature")
+fn has_feature_function(
+    args: &HashMap<String, serde_json::Value>,
+) -> tera::Result<serde_json::Value> {
+    let feature = args
+        .get("feature")
         .and_then(|v| v.as_str())
         .ok_or_else(|| tera::Error::msg("has_feature requires a 'feature' parameter"))?;
-    
-    let features = args.get("features")
+
+    let features = args
+        .get("features")
         .and_then(|v| v.as_array())
         .ok_or_else(|| tera::Error::msg("has_feature requires 'features' in context"))?;
-    
-    let feature_strings: Vec<String> = features.iter()
+
+    let feature_strings: Vec<String> = features
+        .iter()
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
         .collect();
-    
-    Ok(serde_json::Value::Bool(feature_strings.contains(&feature.to_string())))
+
+    Ok(serde_json::Value::Bool(
+        feature_strings.contains(&feature.to_string()),
+    ))
 }
 
 /// Tera function to check if any of the specified features are enabled
-fn has_any_feature_function(args: &HashMap<String, serde_json::Value>) -> tera::Result<serde_json::Value> {
-    let check_features = args.get("check")
+fn has_any_feature_function(
+    args: &HashMap<String, serde_json::Value>,
+) -> tera::Result<serde_json::Value> {
+    let check_features = args
+        .get("check")
         .and_then(|v| v.as_array())
         .ok_or_else(|| tera::Error::msg("has_any_feature requires a 'check' array parameter"))?;
-    
-    let features = args.get("features")
+
+    let features = args
+        .get("features")
         .and_then(|v| v.as_array())
         .ok_or_else(|| tera::Error::msg("has_any_feature requires 'features' in context"))?;
-    
-    let feature_strings: HashSet<String> = features.iter()
+
+    let feature_strings: HashSet<String> = features
+        .iter()
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
         .collect();
-    
+
     for check_feature in check_features {
         if let Some(feature_str) = check_feature.as_str() {
             if feature_strings.contains(feature_str) {
@@ -92,24 +104,29 @@ fn has_any_feature_function(args: &HashMap<String, serde_json::Value>) -> tera::
             }
         }
     }
-    
+
     Ok(serde_json::Value::Bool(false))
 }
 
 /// Tera function to check if all specified features are enabled
-fn has_all_features_function(args: &HashMap<String, serde_json::Value>) -> tera::Result<serde_json::Value> {
-    let check_features = args.get("check")
+fn has_all_features_function(
+    args: &HashMap<String, serde_json::Value>,
+) -> tera::Result<serde_json::Value> {
+    let check_features = args
+        .get("check")
         .and_then(|v| v.as_array())
         .ok_or_else(|| tera::Error::msg("has_all_features requires a 'check' array parameter"))?;
-    
-    let features = args.get("features")
+
+    let features = args
+        .get("features")
         .and_then(|v| v.as_array())
         .ok_or_else(|| tera::Error::msg("has_all_features requires 'features' in context"))?;
-    
-    let feature_strings: HashSet<String> = features.iter()
+
+    let feature_strings: HashSet<String> = features
+        .iter()
         .filter_map(|v| v.as_str().map(|s| s.to_string()))
         .collect();
-    
+
     for check_feature in check_features {
         if let Some(feature_str) = check_feature.as_str() {
             if !feature_strings.contains(feature_str) {
@@ -117,7 +134,7 @@ fn has_all_features_function(args: &HashMap<String, serde_json::Value>) -> tera:
             }
         }
     }
-    
+
     Ok(serde_json::Value::Bool(true))
 }
 
@@ -126,12 +143,16 @@ use std::collections::HashMap;
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_conditional_rendering_with_features() {
-        let mut renderer = ConditionalRenderer::new(vec!["database".to_string(), "auth".to_string()]).unwrap();
-        
-        renderer.add_template("test", r#"
+        let mut renderer =
+            ConditionalRenderer::new(vec!["database".to_string(), "auth".to_string()]).unwrap();
+
+        renderer
+            .add_template(
+                "test",
+                r#"
 Base content
 {% if has_database %}
 Database feature is enabled
@@ -142,21 +163,27 @@ Auth feature is enabled
 {% if has_cache %}
 Cache feature is enabled
 {% endif %}
-"#).unwrap();
-        
+"#,
+            )
+            .unwrap();
+
         let context = Context::new();
         let result = renderer.render("test", context).unwrap();
-        
+
         assert!(result.contains("Database feature is enabled"));
         assert!(result.contains("Auth feature is enabled"));
         assert!(!result.contains("Cache feature is enabled"));
     }
-    
+
     #[test]
     fn test_feature_functions() {
-        let mut renderer = ConditionalRenderer::new(vec!["api".to_string(), "database".to_string()]).unwrap();
-        
-        renderer.add_template("test", r#"
+        let mut renderer =
+            ConditionalRenderer::new(vec!["api".to_string(), "database".to_string()]).unwrap();
+
+        renderer
+            .add_template(
+                "test",
+                r#"
 {% if has_feature(feature="api", features=features) %}
 Has API feature
 {% endif %}
@@ -169,33 +196,41 @@ Has both API and database
 {% if has_all_features(check=["api", "cache"], features=features) %}
 Has both API and cache
 {% endif %}
-"#).unwrap();
-        
+"#,
+            )
+            .unwrap();
+
         let context = Context::new();
         let result = renderer.render("test", context).unwrap();
-        
+
         assert!(result.contains("Has API feature"));
         assert!(result.contains("Has database or cache"));
         assert!(result.contains("Has both API and database"));
         assert!(!result.contains("Has both API and cache"));
     }
-    
+
     #[test]
     fn test_nested_conditionals() {
-        let mut renderer = ConditionalRenderer::new(vec!["api".to_string(), "database".to_string()]).unwrap();
-        
-        renderer.add_template("test", r#"
+        let mut renderer =
+            ConditionalRenderer::new(vec!["api".to_string(), "database".to_string()]).unwrap();
+
+        renderer
+            .add_template(
+                "test",
+                r#"
 {% if has_api %}
 API is enabled
 {% if has_database %}
 Both API and database are enabled
 {% endif %}
 {% endif %}
-"#).unwrap();
-        
+"#,
+            )
+            .unwrap();
+
         let context = Context::new();
         let result = renderer.render("test", context).unwrap();
-        
+
         assert!(result.contains("API is enabled"));
         assert!(result.contains("Both API and database are enabled"));
     }

--- a/tests/auth_feature_test.rs
+++ b/tests/auth_feature_test.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use anyhow::Result;
+use std::collections::HashMap;
 
 /// Mock structure to represent auth feature template generation
 struct AuthFeatureGenerator {
@@ -18,7 +18,7 @@ impl AuthFeatureGenerator {
             include_password_hashing: true,
         }
     }
-    
+
     fn generate_jwt_module(&self) -> String {
         r#"use jsonwebtoken::{encode, decode, Header, Algorithm, Validation, EncodingKey, DecodingKey};
 use serde::{Deserialize, Serialize};
@@ -101,7 +101,7 @@ mod tests {
     }
 }"#.to_string()
     }
-    
+
     fn generate_oauth_module(&self) -> String {
         r#"use oauth2::{
     AuthorizationCode, AuthUrl, ClientId, ClientSecret, CsrfToken, RedirectUrl, 
@@ -200,9 +200,10 @@ pub mod providers {
             redirect_url: env::var("GITHUB_REDIRECT_URL").unwrap_or_default(),
         }
     }
-}"#.to_string()
+}"#
+        .to_string()
     }
-    
+
     fn generate_password_module(&self) -> String {
         r#"use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
@@ -263,7 +264,7 @@ mod tests {
     }
 }"#.to_string()
     }
-    
+
     fn generate_auth_middleware(&self) -> String {
         r#"use axum::{
     async_trait,
@@ -354,7 +355,7 @@ where
     }
 }"#.to_string()
     }
-    
+
     fn generate_auth_routes(&self) -> String {
         r#"use axum::{
     routing::{get, post},
@@ -509,68 +510,60 @@ async fn refresh_token(
 ) -> Result<Json<LoginResponse>, (axum::http::StatusCode, String)> {
     // TODO: Implement refresh token logic
     Err((axum::http::StatusCode::NOT_IMPLEMENTED, "Refresh token not implemented".to_string()))
-}"#.to_string()
+}"#
+        .to_string()
     }
-    
+
     fn generate_file_structure(&self) -> Vec<(String, String)> {
         let mut files = vec![];
-        
+
         // Base auth module
-        files.push((
-            "src/auth/mod.rs".to_string(),
-            self.generate_auth_mod()
-        ));
-        
+        files.push(("src/auth/mod.rs".to_string(), self.generate_auth_mod()));
+
         // JWT support
         if self.auth_types.contains(&"jwt".to_string()) {
-            files.push((
-                "src/auth/jwt.rs".to_string(),
-                self.generate_jwt_module()
-            ));
+            files.push(("src/auth/jwt.rs".to_string(), self.generate_jwt_module()));
         }
-        
+
         // OAuth support
         if self.auth_types.contains(&"oauth".to_string()) {
             files.push((
                 "src/auth/oauth.rs".to_string(),
-                self.generate_oauth_module()
+                self.generate_oauth_module(),
             ));
         }
-        
+
         // Password hashing
         if self.include_password_hashing {
             files.push((
                 "src/auth/password.rs".to_string(),
-                self.generate_password_module()
+                self.generate_password_module(),
             ));
         }
-        
+
         // Middleware
         if self.include_middleware {
             files.push((
                 "src/auth/middleware.rs".to_string(),
-                self.generate_auth_middleware()
+                self.generate_auth_middleware(),
             ));
         }
-        
+
         // Auth routes
         files.push((
             "src/auth/routes.rs".to_string(),
-            self.generate_auth_routes()
+            self.generate_auth_routes(),
         ));
-        
+
         // Environment variables example
-        files.push((
-            ".env.auth.example".to_string(),
-            self.generate_env_example()
-        ));
-        
+        files.push((".env.auth.example".to_string(), self.generate_env_example()));
+
         files
     }
-    
+
     fn generate_auth_mod(&self) -> String {
         let mut modules = vec![];
-        
+
         if self.auth_types.contains(&"jwt".to_string()) {
             modules.push("pub mod jwt;");
         }
@@ -584,20 +577,20 @@ async fn refresh_token(
             modules.push("pub mod middleware;");
         }
         modules.push("pub mod routes;");
-        
+
         modules.join("\n")
     }
-    
+
     fn generate_env_example(&self) -> String {
         let mut env_vars = vec![];
-        
+
         if self.auth_types.contains(&"jwt".to_string()) {
             env_vars.push("# JWT Configuration");
             env_vars.push("JWT_SECRET=your-secret-key-here-min-32-chars");
             env_vars.push("JWT_EXPIRATION=86400");
             env_vars.push("");
         }
-        
+
         if self.auth_types.contains(&"oauth".to_string()) {
             env_vars.push("# OAuth Configuration");
             env_vars.push("# Google OAuth");
@@ -607,34 +600,43 @@ async fn refresh_token(
             env_vars.push("");
             env_vars.push("# GitHub OAuth");
             env_vars.push("GITHUB_CLIENT_ID=your-github-client-id");
-            env_vars.push("GITHUB_CLIENT_SECRET=your-github-client-secret"); 
+            env_vars.push("GITHUB_CLIENT_SECRET=your-github-client-secret");
             env_vars.push("GITHUB_REDIRECT_URL=http://localhost:3000/auth/oauth/github/callback");
         }
-        
+
         env_vars.join("\n")
     }
-    
+
     fn get_required_dependencies(&self) -> HashMap<String, String> {
         let mut deps = HashMap::new();
-        
+
         if self.auth_types.contains(&"jwt".to_string()) {
             deps.insert("jsonwebtoken".to_string(), "\"9\"".to_string());
         }
-        
+
         if self.auth_types.contains(&"oauth".to_string()) {
             deps.insert("oauth2".to_string(), "\"4\"".to_string());
-            deps.insert("reqwest".to_string(), r#"{ version = "0.11", features = ["json"] }"#.to_string());
+            deps.insert(
+                "reqwest".to_string(),
+                r#"{ version = "0.11", features = ["json"] }"#.to_string(),
+            );
         }
-        
+
         if self.include_password_hashing {
             deps.insert("argon2".to_string(), "\"0.5\"".to_string());
         }
-        
+
         // Common auth dependencies
-        deps.insert("serde".to_string(), r#"{ version = "1", features = ["derive"] }"#.to_string());
+        deps.insert(
+            "serde".to_string(),
+            r#"{ version = "1", features = ["derive"] }"#.to_string(),
+        );
         deps.insert("serde_json".to_string(), "\"1\"".to_string());
-        deps.insert("chrono".to_string(), r#"{ version = "0.4", features = ["serde"] }"#.to_string());
-        
+        deps.insert(
+            "chrono".to_string(),
+            r#"{ version = "0.4", features = ["serde"] }"#.to_string(),
+        );
+
         deps
     }
 }
@@ -642,24 +644,24 @@ async fn refresh_token(
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_jwt_module_generation() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string()]);
         let jwt_module = generator.generate_jwt_module();
-        
+
         assert!(jwt_module.contains("use jsonwebtoken"));
         assert!(jwt_module.contains("pub struct Claims"));
         assert!(jwt_module.contains("pub struct JwtManager"));
         assert!(jwt_module.contains("generate_token"));
         assert!(jwt_module.contains("verify_token"));
     }
-    
+
     #[test]
     fn test_oauth_module_generation() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["oauth".to_string()]);
         let oauth_module = generator.generate_oauth_module();
-        
+
         assert!(oauth_module.contains("use oauth2"));
         assert!(oauth_module.contains("pub struct OAuthConfig"));
         assert!(oauth_module.contains("pub struct OAuthClient"));
@@ -668,34 +670,35 @@ mod tests {
         assert!(oauth_module.contains("google_config"));
         assert!(oauth_module.contains("github_config"));
     }
-    
+
     #[test]
     fn test_password_module_generation() {
         let generator = AuthFeatureGenerator::new("my_app", vec![]);
         let password_module = generator.generate_password_module();
-        
+
         assert!(password_module.contains("use argon2"));
         assert!(password_module.contains("pub struct PasswordManager"));
         assert!(password_module.contains("hash_password"));
         assert!(password_module.contains("verify_password"));
     }
-    
+
     #[test]
     fn test_auth_middleware_generation() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string()]);
         let middleware = generator.generate_auth_middleware();
-        
+
         assert!(middleware.contains("pub struct AuthenticatedUser"));
         assert!(middleware.contains("FromRequestParts"));
         assert!(middleware.contains("pub enum AuthError"));
         assert!(middleware.contains("pub struct RequireRole"));
     }
-    
+
     #[test]
     fn test_auth_routes_generation() {
-        let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
+        let generator =
+            AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
         let routes = generator.generate_auth_routes();
-        
+
         assert!(routes.contains("/auth/login"));
         assert!(routes.contains("/auth/register"));
         assert!(routes.contains("/auth/oauth/google"));
@@ -703,13 +706,13 @@ mod tests {
         assert!(routes.contains("LoginRequest"));
         assert!(routes.contains("LoginResponse"));
     }
-    
+
     #[test]
     fn test_file_structure_with_jwt_only() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string()]);
         let files = generator.generate_file_structure();
         let file_paths: Vec<String> = files.iter().map(|(path, _)| path.clone()).collect();
-        
+
         assert!(file_paths.contains(&"src/auth/mod.rs".to_string()));
         assert!(file_paths.contains(&"src/auth/jwt.rs".to_string()));
         assert!(file_paths.contains(&"src/auth/password.rs".to_string()));
@@ -717,65 +720,70 @@ mod tests {
         assert!(file_paths.contains(&"src/auth/routes.rs".to_string()));
         assert!(!file_paths.contains(&"src/auth/oauth.rs".to_string()));
     }
-    
+
     #[test]
     fn test_file_structure_with_oauth_only() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["oauth".to_string()]);
         let files = generator.generate_file_structure();
         let file_paths: Vec<String> = files.iter().map(|(path, _)| path.clone()).collect();
-        
+
         assert!(file_paths.contains(&"src/auth/oauth.rs".to_string()));
         assert!(!file_paths.contains(&"src/auth/jwt.rs".to_string()));
     }
-    
+
     #[test]
     fn test_file_structure_with_all_auth_types() {
-        let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string(), "basic".to_string()]);
+        let generator = AuthFeatureGenerator::new(
+            "my_app",
+            vec!["jwt".to_string(), "oauth".to_string(), "basic".to_string()],
+        );
         let files = generator.generate_file_structure();
         let file_paths: Vec<String> = files.iter().map(|(path, _)| path.clone()).collect();
-        
+
         assert!(file_paths.contains(&"src/auth/jwt.rs".to_string()));
         assert!(file_paths.contains(&"src/auth/oauth.rs".to_string()));
         assert!(file_paths.contains(&"src/auth/password.rs".to_string()));
         assert!(file_paths.contains(&"src/auth/middleware.rs".to_string()));
     }
-    
+
     #[test]
     fn test_env_example_generation() {
-        let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
+        let generator =
+            AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
         let env_example = generator.generate_env_example();
-        
+
         assert!(env_example.contains("JWT_SECRET"));
         assert!(env_example.contains("GOOGLE_CLIENT_ID"));
         assert!(env_example.contains("GITHUB_CLIENT_ID"));
     }
-    
+
     #[test]
     fn test_required_dependencies_jwt() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string()]);
         let deps = generator.get_required_dependencies();
-        
+
         assert!(deps.contains_key("jsonwebtoken"));
         assert!(deps.contains_key("chrono"));
         assert!(deps.contains_key("serde"));
         assert!(!deps.contains_key("oauth2"));
     }
-    
+
     #[test]
     fn test_required_dependencies_oauth() {
         let generator = AuthFeatureGenerator::new("my_app", vec!["oauth".to_string()]);
         let deps = generator.get_required_dependencies();
-        
+
         assert!(deps.contains_key("oauth2"));
         assert!(deps.contains_key("reqwest"));
         assert!(!deps.contains_key("jsonwebtoken"));
     }
-    
+
     #[test]
     fn test_required_dependencies_all_features() {
-        let generator = AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
+        let generator =
+            AuthFeatureGenerator::new("my_app", vec!["jwt".to_string(), "oauth".to_string()]);
         let deps = generator.get_required_dependencies();
-        
+
         assert!(deps.contains_key("jsonwebtoken"));
         assert!(deps.contains_key("oauth2"));
         assert!(deps.contains_key("argon2"));

--- a/tests/cargo_toml_feature_test.rs
+++ b/tests/cargo_toml_feature_test.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use toml::{Value, Table};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use toml::{Table, Value};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CargoToml {
@@ -41,28 +41,28 @@ impl FeatureDependencyManager {
             feature_dev_dependencies: HashMap::new(),
         }
     }
-    
+
     fn add_base_dependency(&mut self, name: &str, version: Value) {
         self.base_dependencies.insert(name.to_string(), version);
     }
-    
+
     fn add_feature_dependency(&mut self, feature: &str, name: &str, version: Value) {
         self.feature_dependencies
             .entry(feature.to_string())
             .or_insert_with(Table::new)
             .insert(name.to_string(), version);
     }
-    
+
     fn add_feature_dev_dependency(&mut self, feature: &str, name: &str, version: Value) {
         self.feature_dev_dependencies
             .entry(feature.to_string())
             .or_insert_with(Table::new)
             .insert(name.to_string(), version);
     }
-    
+
     fn build_dependencies(&self, features: &[String]) -> Table {
         let mut dependencies = self.base_dependencies.clone();
-        
+
         for feature in features {
             if let Some(feature_deps) = self.feature_dependencies.get(feature) {
                 for (name, version) in feature_deps {
@@ -70,13 +70,13 @@ impl FeatureDependencyManager {
                 }
             }
         }
-        
+
         dependencies
     }
-    
+
     fn build_dev_dependencies(&self, features: &[String]) -> Table {
         let mut dev_dependencies = self.base_dev_dependencies.clone();
-        
+
         for feature in features {
             if let Some(feature_deps) = self.feature_dev_dependencies.get(feature) {
                 for (name, version) in feature_deps {
@@ -84,7 +84,7 @@ impl FeatureDependencyManager {
                 }
             }
         }
-        
+
         dev_dependencies
     }
 }
@@ -92,104 +92,146 @@ impl FeatureDependencyManager {
 /// Initialize feature dependencies
 fn init_feature_dependencies() -> FeatureDependencyManager {
     let mut manager = FeatureDependencyManager::new();
-    
+
     // Base dependencies (always included)
-    manager.add_base_dependency("serde", toml::toml! {
-        version = "1"
-        features = ["derive"]
-    }.into());
-    manager.add_base_dependency("tokio", toml::toml! {
-        version = "1"
-        features = ["full"]
-    }.into());
-    
+    manager.add_base_dependency(
+        "serde",
+        toml::toml! {
+            version = "1"
+            features = ["derive"]
+        }
+        .into(),
+    );
+    manager.add_base_dependency(
+        "tokio",
+        toml::toml! {
+            version = "1"
+            features = ["full"]
+        }
+        .into(),
+    );
+
     // Database feature dependencies
-    manager.add_feature_dependency("database", "sqlx", toml::toml! {
-        version = "0.7"
-        features = ["runtime-tokio-native-tls", "postgres", "chrono", "uuid"]
-    }.into());
-    manager.add_feature_dependency("database", "chrono", toml::toml! {
-        version = "0.4"
-        features = ["serde"]
-    }.into());
-    manager.add_feature_dependency("database", "uuid", toml::toml! {
-        version = "1"
-        features = ["v4", "serde"]
-    }.into());
-    
+    manager.add_feature_dependency(
+        "database",
+        "sqlx",
+        toml::toml! {
+            version = "0.7"
+            features = ["runtime-tokio-native-tls", "postgres", "chrono", "uuid"]
+        }
+        .into(),
+    );
+    manager.add_feature_dependency(
+        "database",
+        "chrono",
+        toml::toml! {
+            version = "0.4"
+            features = ["serde"]
+        }
+        .into(),
+    );
+    manager.add_feature_dependency(
+        "database",
+        "uuid",
+        toml::toml! {
+            version = "1"
+            features = ["v4", "serde"]
+        }
+        .into(),
+    );
+
     // Auth feature dependencies
     manager.add_feature_dependency("auth", "jsonwebtoken", Value::String("9".to_string()));
     manager.add_feature_dependency("auth", "argon2", Value::String("0.5".to_string()));
-    manager.add_feature_dependency("auth", "validator", toml::toml! {
-        version = "0.16"
-        features = ["derive"]
-    }.into());
+    manager.add_feature_dependency(
+        "auth",
+        "validator",
+        toml::toml! {
+            version = "0.16"
+            features = ["derive"]
+        }
+        .into(),
+    );
     manager.add_feature_dependency("auth", "once_cell", Value::String("1".to_string()));
     manager.add_feature_dependency("auth", "rand", Value::String("0.8".to_string()));
     manager.add_feature_dependency("auth", "zeroize", Value::String("1".to_string()));
-    
+
     // OAuth sub-feature of auth
     manager.add_feature_dependency("oauth", "oauth2", Value::String("4".to_string()));
-    manager.add_feature_dependency("oauth", "reqwest", toml::toml! {
-        version = "0.11"
-        features = ["json"]
-    }.into());
-    
+    manager.add_feature_dependency(
+        "oauth",
+        "reqwest",
+        toml::toml! {
+            version = "0.11"
+            features = ["json"]
+        }
+        .into(),
+    );
+
     // API feature dependencies
     manager.add_feature_dependency("api", "axum", Value::String("0.7".to_string()));
     manager.add_feature_dependency("api", "tower", Value::String("0.4".to_string()));
-    manager.add_feature_dependency("api", "tower-http", toml::toml! {
-        version = "0.5"
-        features = ["fs", "trace", "cors"]
-    }.into());
-    
+    manager.add_feature_dependency(
+        "api",
+        "tower-http",
+        toml::toml! {
+            version = "0.5"
+            features = ["fs", "trace", "cors"]
+        }
+        .into(),
+    );
+
     // Docker feature dependencies (mostly dev dependencies)
-    manager.add_feature_dev_dependency("docker", "testcontainers", Value::String("0.15".to_string()));
-    
+    manager.add_feature_dev_dependency(
+        "docker",
+        "testcontainers",
+        Value::String("0.15".to_string()),
+    );
+
     // CI feature dependencies
     manager.add_feature_dev_dependency("ci", "cargo-tarpaulin", Value::String("0.27".to_string()));
-    
+
     manager
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_base_dependencies_only() {
         let manager = init_feature_dependencies();
         let deps = manager.build_dependencies(&[]);
-        
+
         assert!(deps.contains_key("serde"));
         assert!(deps.contains_key("tokio"));
         assert!(!deps.contains_key("sqlx"));
         assert!(!deps.contains_key("jsonwebtoken"));
     }
-    
+
     #[test]
     fn test_database_feature_dependencies() {
         let manager = init_feature_dependencies();
         let deps = manager.build_dependencies(&["database".to_string()]);
-        
+
         // Should have base dependencies
         assert!(deps.contains_key("serde"));
         assert!(deps.contains_key("tokio"));
-        
+
         // Should have database dependencies
         assert!(deps.contains_key("sqlx"));
         assert!(deps.contains_key("chrono"));
         assert!(deps.contains_key("uuid"));
-        
+
         // Should not have auth dependencies
         assert!(!deps.contains_key("jsonwebtoken"));
     }
-    
+
     #[test]
     fn test_auth_feature_dependencies() {
         let manager = init_feature_dependencies();
         let deps = manager.build_dependencies(&["auth".to_string()]);
-        
+
         // Should have auth dependencies
         assert!(deps.contains_key("jsonwebtoken"));
         assert!(deps.contains_key("argon2"));
@@ -197,24 +239,24 @@ mod tests {
         assert!(deps.contains_key("once_cell"));
         assert!(deps.contains_key("rand"));
         assert!(deps.contains_key("zeroize"));
-        
+
         // Should not have database dependencies
         assert!(!deps.contains_key("sqlx"));
     }
-    
+
     #[test]
     fn test_oauth_feature_dependencies() {
         let manager = init_feature_dependencies();
         let deps = manager.build_dependencies(&["auth".to_string(), "oauth".to_string()]);
-        
+
         // Should have auth dependencies
         assert!(deps.contains_key("jsonwebtoken"));
-        
+
         // Should have oauth dependencies
         assert!(deps.contains_key("oauth2"));
         assert!(deps.contains_key("reqwest"));
     }
-    
+
     #[test]
     fn test_multiple_features_combined() {
         let manager = init_feature_dependencies();
@@ -223,7 +265,7 @@ mod tests {
             "auth".to_string(),
             "api".to_string(),
         ]);
-        
+
         // Should have all feature dependencies
         assert!(deps.contains_key("sqlx"));
         assert!(deps.contains_key("jsonwebtoken"));
@@ -231,42 +273,41 @@ mod tests {
         assert!(deps.contains_key("tower"));
         assert!(deps.contains_key("tower-http"));
     }
-    
+
     #[test]
     fn test_dev_dependencies_with_features() {
         let manager = init_feature_dependencies();
-        let dev_deps = manager.build_dev_dependencies(&[
-            "docker".to_string(),
-            "ci".to_string(),
-        ]);
-        
+        let dev_deps = manager.build_dev_dependencies(&["docker".to_string(), "ci".to_string()]);
+
         assert!(dev_deps.contains_key("testcontainers"));
         assert!(dev_deps.contains_key("cargo-tarpaulin"));
     }
-    
+
     #[test]
     fn test_dependency_version_formats() {
         let manager = init_feature_dependencies();
         let deps = manager.build_dependencies(&["database".to_string()]);
-        
+
         // Test that sqlx has proper feature configuration
         let sqlx_dep = deps.get("sqlx").unwrap();
         if let Value::Table(table) = sqlx_dep {
             assert_eq!(table.get("version").unwrap().as_str().unwrap(), "0.7");
-            
+
             let features = table.get("features").unwrap().as_array().unwrap();
             assert!(features.iter().any(|f| f.as_str().unwrap() == "postgres"));
-            assert!(features.iter().any(|f| f.as_str().unwrap() == "runtime-tokio-native-tls"));
+            assert!(features
+                .iter()
+                .any(|f| f.as_str().unwrap() == "runtime-tokio-native-tls"));
         } else {
             panic!("sqlx dependency should be a table");
         }
     }
-    
+
     #[test]
     fn test_cargo_toml_generation() {
         let manager = init_feature_dependencies();
         let features = vec!["database".to_string(), "auth".to_string()];
-        
+
         let cargo_toml = CargoToml {
             package: Package {
                 name: "test-app".to_string(),
@@ -280,10 +321,10 @@ mod tests {
             features: HashMap::new(),
             other: Table::new(),
         };
-        
+
         // Serialize to TOML string
         let toml_string = toml::to_string_pretty(&cargo_toml).unwrap();
-        
+
         // Verify the output contains expected content
         assert!(toml_string.contains("[package]"));
         assert!(toml_string.contains("name = \"test-app\""));
@@ -291,29 +332,30 @@ mod tests {
         assert!(toml_string.contains("sqlx"));
         assert!(toml_string.contains("jsonwebtoken"));
     }
-    
+
     #[test]
     fn test_conditional_dependency_inclusion() {
         let manager = init_feature_dependencies();
-        
+
         // Test that oauth dependencies are only included when oauth feature is enabled
         let deps_without_oauth = manager.build_dependencies(&["auth".to_string()]);
         assert!(!deps_without_oauth.contains_key("oauth2"));
-        
-        let deps_with_oauth = manager.build_dependencies(&["auth".to_string(), "oauth".to_string()]);
+
+        let deps_with_oauth =
+            manager.build_dependencies(&["auth".to_string(), "oauth".to_string()]);
         assert!(deps_with_oauth.contains_key("oauth2"));
     }
-    
+
     #[test]
     fn test_no_duplicate_dependencies() {
         let mut manager = FeatureDependencyManager::new();
-        
+
         // Add same dependency in base and feature
         manager.add_base_dependency("common", Value::String("1.0".to_string()));
         manager.add_feature_dependency("feature1", "common", Value::String("2.0".to_string()));
-        
+
         let deps = manager.build_dependencies(&["feature1".to_string()]);
-        
+
         // Feature version should override base version
         assert_eq!(deps.get("common").unwrap().as_str().unwrap(), "2.0");
     }

--- a/tests/conditional_template_test.rs
+++ b/tests/conditional_template_test.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
-use std::path::Path;
-use std::fs;
 use anyhow::Result;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 
 /// Test helper to create a mock template renderer that supports conditional rendering
 struct ConditionalTemplateRenderer {
@@ -16,33 +16,36 @@ impl ConditionalTemplateRenderer {
             templates: HashMap::new(),
         }
     }
-    
+
     fn add_template(&mut self, name: &str, content: &str) {
         self.templates.insert(name.to_string(), content.to_string());
     }
-    
+
     fn has_feature(&self, feature: &str) -> bool {
         self.features.contains(&feature.to_string())
     }
-    
+
     fn render(&self, template_name: &str) -> Result<String> {
-        let template = self.templates.get(template_name)
+        let template = self
+            .templates
+            .get(template_name)
             .ok_or_else(|| anyhow::anyhow!("Template not found: {}", template_name))?;
-        
+
         // Simple conditional rendering implementation for testing
         let mut result = String::new();
         let mut lines = template.lines();
         let mut skip_until_endif = false;
-        
+
         while let Some(line) = lines.next() {
             if line.trim().starts_with("{{#if ") && line.trim().ends_with("}}") {
-                let feature = line.trim()
+                let feature = line
+                    .trim()
                     .strip_prefix("{{#if ")
                     .unwrap()
                     .strip_suffix("}}")
                     .unwrap()
                     .trim();
-                    
+
                 skip_until_endif = !self.has_feature(feature);
             } else if line.trim() == "{{/if}}" {
                 skip_until_endif = false;
@@ -51,7 +54,7 @@ impl ConditionalTemplateRenderer {
                 result.push('\n');
             }
         }
-        
+
         Ok(result.trim_end().to_string())
     }
 }
@@ -59,12 +62,14 @@ impl ConditionalTemplateRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_conditional_rendering_with_database_feature() {
         let mut renderer = ConditionalTemplateRenderer::new(vec!["database".to_string()]);
-        
-        renderer.add_template("main.rs", r#"use std::env;
+
+        renderer.add_template(
+            "main.rs",
+            r#"use std::env;
 
 {{#if database}}
 use sqlx::PgPool;
@@ -75,22 +80,25 @@ fn main() {
     {{#if database}}
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     {{/if}}
-}"#);
+}"#,
+        );
 
         let result = renderer.render("main.rs").unwrap();
-        
+
         // Should include database imports and code
         assert!(result.contains("use sqlx::PgPool;"));
         assert!(result.contains("DATABASE_URL"));
         assert!(!result.contains("{{#if"));
         assert!(!result.contains("{{/if}}"));
     }
-    
+
     #[test]
     fn test_conditional_rendering_without_database_feature() {
         let mut renderer = ConditionalTemplateRenderer::new(vec![]);
-        
-        renderer.add_template("main.rs", r#"use std::env;
+
+        renderer.add_template(
+            "main.rs",
+            r#"use std::env;
 
 {{#if database}}
 use sqlx::PgPool;
@@ -101,22 +109,25 @@ fn main() {
     {{#if database}}
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
     {{/if}}
-}"#);
+}"#,
+        );
 
         let result = renderer.render("main.rs").unwrap();
-        
+
         // Should NOT include database imports and code
         assert!(!result.contains("use sqlx::PgPool;"));
         assert!(!result.contains("DATABASE_URL"));
         assert!(!result.contains("{{#if"));
         assert!(!result.contains("{{/if}}"));
     }
-    
+
     #[test]
     fn test_conditional_rendering_with_auth_feature() {
         let mut renderer = ConditionalTemplateRenderer::new(vec!["auth".to_string()]);
-        
-        renderer.add_template("lib.rs", r#"pub mod routes;
+
+        renderer.add_template(
+            "lib.rs",
+            r#"pub mod routes;
 {{#if auth}}
 pub mod auth;
 pub mod jwt;
@@ -129,26 +140,29 @@ pub fn init() {
     {{#if auth}}
     auth::init_auth_system();
     {{/if}}
-}"#);
+}"#,
+        );
 
         let result = renderer.render("lib.rs").unwrap();
-        
+
         // Should include auth modules but not database
         assert!(result.contains("pub mod auth;"));
         assert!(result.contains("pub mod jwt;"));
         assert!(result.contains("auth::init_auth_system()"));
         assert!(!result.contains("pub mod db;"));
     }
-    
+
     #[test]
     fn test_conditional_rendering_multiple_features() {
         let mut renderer = ConditionalTemplateRenderer::new(vec![
             "database".to_string(),
             "auth".to_string(),
-            "docker".to_string()
+            "docker".to_string(),
         ]);
-        
-        renderer.add_template("Cargo.toml", r#"[package]
+
+        renderer.add_template(
+            "Cargo.toml",
+            r#"[package]
 name = "my-app"
 version = "0.1.0"
 
@@ -165,25 +179,26 @@ bcrypt = "0.14"
 [dev-dependencies]
 {{#if docker}}
 testcontainers = "0.15"
-{{/if}}"#);
+{{/if}}"#,
+        );
 
         let result = renderer.render("Cargo.toml").unwrap();
-        
+
         // Should include all feature dependencies
         assert!(result.contains("sqlx ="));
         assert!(result.contains("jsonwebtoken ="));
         assert!(result.contains("bcrypt ="));
         assert!(result.contains("testcontainers ="));
     }
-    
+
     #[test]
     fn test_nested_conditional_rendering() {
-        let mut renderer = ConditionalTemplateRenderer::new(vec![
-            "api".to_string(),
-            "database".to_string()
-        ]);
-        
-        renderer.add_template("main.rs", r#"{{#if api}}
+        let mut renderer =
+            ConditionalTemplateRenderer::new(vec!["api".to_string(), "database".to_string()]);
+
+        renderer.add_template(
+            "main.rs",
+            r#"{{#if api}}
 use axum::{Router, routing::get};
 {{#if database}}
 use sqlx::PgPool;
@@ -197,24 +212,25 @@ async fn main() {
     let app = Router::new()
         .route("/", get(handler));
 }
-{{/if}}"#);
+{{/if}}"#,
+        );
 
         let result = renderer.render("main.rs").unwrap();
-        
+
         // Should include both API and database code
         assert!(result.contains("use axum::{Router, routing::get};"));
         assert!(result.contains("use sqlx::PgPool;"));
         assert!(result.contains("PgPool::connect"));
     }
-    
+
     #[test]
     fn test_feature_combination_api_plus_database() {
-        let mut renderer = ConditionalTemplateRenderer::new(vec![
-            "api".to_string(),
-            "database".to_string()
-        ]);
-        
-        renderer.add_template("dependencies", r#"axum = "0.7"
+        let mut renderer =
+            ConditionalTemplateRenderer::new(vec!["api".to_string(), "database".to_string()]);
+
+        renderer.add_template(
+            "dependencies",
+            r#"axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 {{#if database}}
 sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-native-tls"] }
@@ -222,25 +238,26 @@ diesel = { version = "2.1", features = ["postgres"] }
 {{/if}}
 {{#if auth}}
 jsonwebtoken = "9.0"
-{{/if}}"#);
+{{/if}}"#,
+        );
 
         let result = renderer.render("dependencies").unwrap();
-        
+
         // API + Database should include database dependencies
         assert!(result.contains("sqlx ="));
         assert!(result.contains("diesel ="));
         // But not auth dependencies
         assert!(!result.contains("jsonwebtoken"));
     }
-    
+
     #[test]
     fn test_feature_combination_api_plus_docker() {
-        let mut renderer = ConditionalTemplateRenderer::new(vec![
-            "api".to_string(),
-            "docker".to_string()
-        ]);
-        
-        renderer.add_template("docker-compose.yml", r#"version: '3.8'
+        let mut renderer =
+            ConditionalTemplateRenderer::new(vec!["api".to_string(), "docker".to_string()]);
+
+        renderer.add_template(
+            "docker-compose.yml",
+            r#"version: '3.8'
 
 services:
   app:
@@ -258,43 +275,44 @@ services:
     image: redis:7
     ports:
       - "6379:6379"
-{{/if}}"#);
+{{/if}}"#,
+        );
 
         let result = renderer.render("docker-compose.yml").unwrap();
-        
+
         // Should have app service but not database or redis
         assert!(result.contains("app:"));
         assert!(result.contains("3000:3000"));
         assert!(!result.contains("postgres:"));
         assert!(!result.contains("redis:"));
     }
-    
-    #[test] 
+
+    #[test]
     fn test_template_file_selection_based_on_features() {
         // Test that different template files are selected based on features
         let features = vec!["database".to_string()];
-        
+
         let template_files = get_template_files_for_features(&features);
-        
+
         assert!(template_files.contains(&"templates/features/database/db.rs"));
         assert!(template_files.contains(&"templates/features/database/migrations/001_initial.sql"));
         assert!(!template_files.contains(&"templates/features/auth/jwt.rs"));
     }
-    
+
     #[test]
     fn test_cargo_toml_dependency_merging() {
         // Test that dependencies from multiple features are properly merged
         let mut base_deps = HashMap::new();
         base_deps.insert("tokio".to_string(), "1.0".to_string());
-        
+
         let mut db_deps = HashMap::new();
         db_deps.insert("sqlx".to_string(), "0.7".to_string());
-        
+
         let mut auth_deps = HashMap::new();
         auth_deps.insert("jsonwebtoken".to_string(), "9.0".to_string());
-        
+
         let merged = merge_dependencies(vec![base_deps, db_deps, auth_deps]);
-        
+
         assert_eq!(merged.get("tokio").unwrap(), "1.0");
         assert_eq!(merged.get("sqlx").unwrap(), "0.7");
         assert_eq!(merged.get("jsonwebtoken").unwrap(), "9.0");
@@ -304,28 +322,28 @@ services:
 // Helper functions that would be implemented in the actual code
 fn get_template_files_for_features(features: &[String]) -> Vec<&'static str> {
     let mut files = vec![];
-    
+
     if features.contains(&"database".to_string()) {
         files.push("templates/features/database/db.rs");
         files.push("templates/features/database/migrations/001_initial.sql");
     }
-    
+
     if features.contains(&"auth".to_string()) {
         files.push("templates/features/auth/jwt.rs");
         files.push("templates/features/auth/oauth.rs");
     }
-    
+
     files
 }
 
 fn merge_dependencies(deps_list: Vec<HashMap<String, String>>) -> HashMap<String, String> {
     let mut merged = HashMap::new();
-    
+
     for deps in deps_list {
         for (key, value) in deps {
             merged.insert(key, value);
         }
     }
-    
+
     merged
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,12 +1,12 @@
+use cargo_forge::config::Config;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
-use cargo_forge::config::Config;
 
 #[test]
 fn test_config_new_with_defaults() {
     let config = Config::new();
-    
+
     assert_eq!(config.default_author, None);
     assert_eq!(config.default_license, None);
     assert_eq!(config.default_ci, None);
@@ -18,7 +18,7 @@ fn test_config_new_with_defaults() {
 fn test_config_with_values() {
     let mut custom_dirs = Vec::new();
     custom_dirs.push(PathBuf::from("/custom/templates"));
-    
+
     let config = Config {
         default_author: Some("Jane Doe".to_string()),
         default_license: Some("MIT".to_string()),
@@ -26,7 +26,7 @@ fn test_config_with_values() {
         custom_template_dirs: custom_dirs,
         remember_choices: false,
     };
-    
+
     assert_eq!(config.default_author, Some("Jane Doe".to_string()));
     assert_eq!(config.default_license, Some("MIT".to_string()));
     assert_eq!(config.default_ci, Some("github".to_string()));
@@ -38,7 +38,7 @@ fn test_config_with_values() {
 fn test_config_load_from_file() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("config.toml");
-    
+
     let config_content = r#"
 default_author = "John Doe"
 default_license = "Apache-2.0"
@@ -46,17 +46,23 @@ default_ci = "gitlab"
 custom_template_dirs = ["/home/user/templates", "/opt/templates"]
 remember_choices = false
 "#;
-    
+
     fs::write(&config_path, config_content).unwrap();
-    
+
     let config = Config::load_from_file(&config_path).unwrap();
-    
+
     assert_eq!(config.default_author, Some("John Doe".to_string()));
     assert_eq!(config.default_license, Some("Apache-2.0".to_string()));
     assert_eq!(config.default_ci, Some("gitlab".to_string()));
     assert_eq!(config.custom_template_dirs.len(), 2);
-    assert_eq!(config.custom_template_dirs[0], PathBuf::from("/home/user/templates"));
-    assert_eq!(config.custom_template_dirs[1], PathBuf::from("/opt/templates"));
+    assert_eq!(
+        config.custom_template_dirs[0],
+        PathBuf::from("/home/user/templates")
+    );
+    assert_eq!(
+        config.custom_template_dirs[1],
+        PathBuf::from("/opt/templates")
+    );
     assert_eq!(config.remember_choices, false);
 }
 
@@ -64,9 +70,9 @@ remember_choices = false
 fn test_config_load_from_nonexistent_file() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("nonexistent.toml");
-    
+
     let config = Config::load_from_file(&config_path).unwrap();
-    
+
     // Should return default config when file doesn't exist
     assert_eq!(config.default_author, None);
     assert_eq!(config.default_license, None);
@@ -79,10 +85,10 @@ fn test_config_load_from_nonexistent_file() {
 fn test_config_save_to_file() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("config.toml");
-    
+
     let mut custom_dirs = Vec::new();
     custom_dirs.push(PathBuf::from("/home/user/my-templates"));
-    
+
     let config = Config {
         default_author: Some("Alice Smith".to_string()),
         default_license: Some("MIT".to_string()),
@@ -90,9 +96,9 @@ fn test_config_save_to_file() {
         custom_template_dirs: custom_dirs,
         remember_choices: true,
     };
-    
+
     config.save_to_file(&config_path).unwrap();
-    
+
     let saved_content = fs::read_to_string(&config_path).unwrap();
     assert!(saved_content.contains("default_author = \"Alice Smith\""));
     assert!(saved_content.contains("default_license = \"MIT\""));
@@ -105,21 +111,21 @@ fn test_config_save_to_file() {
 fn test_config_load_from_home_directory() {
     let temp_dir = TempDir::new().unwrap();
     let home_dir = temp_dir.path();
-    
+
     // Create .cargo-forge directory
     let cargo_forge_dir = home_dir.join(".cargo-forge");
     fs::create_dir_all(&cargo_forge_dir).unwrap();
-    
+
     let config_path = cargo_forge_dir.join("config.toml");
     let config_content = r#"
 default_author = "Home User"
 default_license = "BSD-3-Clause"
 "#;
-    
+
     fs::write(&config_path, config_content).unwrap();
-    
+
     let config = Config::load_from_home_with_path(home_dir).unwrap();
-    
+
     assert_eq!(config.default_author, Some("Home User".to_string()));
     assert_eq!(config.default_license, Some("BSD-3-Clause".to_string()));
 }
@@ -133,13 +139,13 @@ fn test_config_merge_with_cli_args() {
         custom_template_dirs: vec![PathBuf::from("/config/templates")],
         remember_choices: true,
     };
-    
+
     let cli_author = Some("CLI Author".to_string());
     let cli_license = None;
     let cli_ci = Some("gitlab".to_string());
-    
+
     let merged = config.merge_with_cli(cli_author, cli_license, cli_ci);
-    
+
     // CLI args should override config values
     assert_eq!(merged.default_author, Some("CLI Author".to_string()));
     assert_eq!(merged.default_license, Some("MIT".to_string())); // unchanged from config
@@ -157,9 +163,9 @@ fn test_config_merge_with_empty_cli_args() {
         custom_template_dirs: vec![PathBuf::from("/config/templates")],
         remember_choices: false,
     };
-    
+
     let merged = config.merge_with_cli(None, None, None);
-    
+
     // Config values should remain unchanged when CLI args are None
     assert_eq!(merged.default_author, Some("Config Author".to_string()));
     assert_eq!(merged.default_license, Some("MIT".to_string()));
@@ -172,9 +178,9 @@ fn test_config_merge_with_empty_cli_args() {
 fn test_config_add_custom_template_directory() {
     let mut config = Config::new();
     let template_dir = PathBuf::from("/new/template/dir");
-    
+
     config.add_custom_template_directory(template_dir.clone());
-    
+
     assert_eq!(config.custom_template_dirs.len(), 1);
     assert_eq!(config.custom_template_dirs[0], template_dir);
 }
@@ -183,10 +189,10 @@ fn test_config_add_custom_template_directory() {
 fn test_config_add_duplicate_template_directory() {
     let mut config = Config::new();
     let template_dir = PathBuf::from("/template/dir");
-    
+
     config.add_custom_template_directory(template_dir.clone());
     config.add_custom_template_directory(template_dir.clone()); // duplicate
-    
+
     // Should not add duplicates
     assert_eq!(config.custom_template_dirs.len(), 1);
     assert_eq!(config.custom_template_dirs[0], template_dir);
@@ -195,15 +201,15 @@ fn test_config_add_duplicate_template_directory() {
 #[test]
 fn test_config_remember_choice_functionality() {
     let mut config = Config::new();
-    
+
     // Test remembering author choice
     config.remember_choice("author", "Remembered Author");
     assert_eq!(config.default_author, Some("Remembered Author".to_string()));
-    
+
     // Test remembering license choice
     config.remember_choice("license", "Apache-2.0");
     assert_eq!(config.default_license, Some("Apache-2.0".to_string()));
-    
+
     // Test remembering CI choice
     config.remember_choice("ci", "gitlab");
     assert_eq!(config.default_ci, Some("gitlab".to_string()));
@@ -215,9 +221,9 @@ fn test_config_remember_choice_disabled() {
         remember_choices: false,
         ..Config::new()
     };
-    
+
     config.remember_choice("author", "Should Not Remember");
-    
+
     // Should not remember when remember_choices is false
     assert_eq!(config.default_author, None);
 }
@@ -231,16 +237,25 @@ fn test_config_get_effective_value() {
         custom_template_dirs: vec![],
         remember_choices: true,
     };
-    
+
     // Test getting existing value
-    assert_eq!(config.get_effective_author(None), Some("Config Author".to_string()));
-    
+    assert_eq!(
+        config.get_effective_author(None),
+        Some("Config Author".to_string())
+    );
+
     // Test CLI override
-    assert_eq!(config.get_effective_author(Some("CLI Author".to_string())), Some("CLI Author".to_string()));
-    
+    assert_eq!(
+        config.get_effective_author(Some("CLI Author".to_string())),
+        Some("CLI Author".to_string())
+    );
+
     // Test None when no value
     assert_eq!(config.get_effective_license(None), None);
-    
+
     // Test CLI value when config is None
-    assert_eq!(config.get_effective_license(Some("MIT".to_string())), Some("MIT".to_string()));
+    assert_eq!(
+        config.get_effective_license(Some("MIT".to_string())),
+        Some("MIT".to_string())
+    );
 }

--- a/tests/database_feature_test.rs
+++ b/tests/database_feature_test.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use anyhow::Result;
 
 /// Mock structure to represent database feature template generation
 struct DatabaseFeatureGenerator {
@@ -19,7 +19,7 @@ impl DatabaseFeatureGenerator {
             include_pool: true,
         }
     }
-    
+
     fn generate_db_module(&self) -> String {
         let pool_type = match self.database_type.as_str() {
             "postgres" => "PgPool",
@@ -27,8 +27,9 @@ impl DatabaseFeatureGenerator {
             "sqlite" => "SqlitePool",
             _ => "PgPool",
         };
-        
-        format!(r#"use sqlx::{{{}, Pool}};
+
+        format!(
+            r#"use sqlx::{{{}, Pool}};
 use std::env;
 
 pub type DbPool = {};
@@ -48,12 +49,15 @@ mod tests {{
     async fn test_pool_creation() {{
         // Test database connection
     }}
-}}"#, pool_type, pool_type, pool_type)
+}}"#,
+            pool_type, pool_type, pool_type
+        )
     }
-    
+
     fn generate_migration_file(&self, number: u32, name: &str) -> String {
         match self.database_type.as_str() {
-            "postgres" => format!(r#"-- Migration: {}
+            "postgres" => format!(
+                r#"-- Migration: {}
 
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
@@ -74,9 +78,12 @@ END;
 $$ language 'plpgsql';
 
 CREATE TRIGGER update_users_updated_at BEFORE UPDATE
-    ON users FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();"#, name),
-            
-            "mysql" => format!(r#"-- Migration: {}
+    ON users FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();"#,
+                name
+            ),
+
+            "mysql" => format!(
+                r#"-- Migration: {}
 
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
@@ -85,9 +92,12 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-CREATE INDEX idx_users_email ON users(email);"#, name),
-            
-            "sqlite" => format!(r#"-- Migration: {}
+CREATE INDEX idx_users_email ON users(email);"#,
+                name
+            ),
+
+            "sqlite" => format!(
+                r#"-- Migration: {}
 
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -103,14 +113,17 @@ CREATE TRIGGER update_users_updated_at
 AFTER UPDATE ON users
 BEGIN
     UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
-END;"#, name),
-            
+END;"#,
+                name
+            ),
+
             _ => String::new(),
         }
     }
-    
+
     fn generate_models(&self) -> String {
-        format!(r#"use chrono::{{DateTime, Utc}};
+        format!(
+            r#"use chrono::{{DateTime, Utc}};
 use serde::{{Deserialize, Serialize}};
 use sqlx::FromRow;
 
@@ -142,48 +155,50 @@ impl User {{
         .fetch_one(pool)
         .await
     }}
-}}"#)
+}}"#
+        )
     }
-    
+
     fn generate_file_structure(&self) -> Vec<(String, String)> {
         let mut files = vec![];
-        
+
         // Main database module
         files.push(("src/db.rs".to_string(), self.generate_db_module()));
-        
+
         // Models
         files.push(("src/models.rs".to_string(), self.generate_models()));
-        
+
         // Migrations
         if self.include_migrations {
             files.push((
                 "migrations/001_create_users.sql".to_string(),
-                self.generate_migration_file(1, "create_users")
+                self.generate_migration_file(1, "create_users"),
             ));
-            
+
             files.push((
                 "migrations/002_create_sessions.sql".to_string(),
-                self.generate_migration_file(2, "create_sessions")
+                self.generate_migration_file(2, "create_sessions"),
             ));
         }
-        
+
         // Database configuration
         files.push((
             "src/config/database.rs".to_string(),
-            self.generate_database_config()
+            self.generate_database_config(),
         ));
-        
+
         // Migration runner
         files.push((
             "src/bin/migrate.rs".to_string(),
-            self.generate_migration_runner()
+            self.generate_migration_runner(),
         ));
-        
+
         files
     }
-    
+
     fn generate_database_config(&self) -> String {
-        format!(r#"use serde::{{Deserialize, Serialize}};
+        format!(
+            r#"use serde::{{Deserialize, Serialize}};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DatabaseConfig {{
@@ -204,9 +219,11 @@ impl Default for DatabaseConfig {{
             idle_timeout: 600,
         }}
     }}
-}}"#, self.project_name)
+}}"#,
+            self.project_name
+        )
     }
-    
+
     fn generate_migration_runner(&self) -> String {
         r#"use sqlx::migrate::Migrator;
 use std::env;
@@ -224,23 +241,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Migrations completed successfully!");
     
     Ok(())
-}"#.to_string()
+}"#
+        .to_string()
     }
-    
+
     fn get_required_dependencies(&self) -> HashMap<String, String> {
         let mut deps = HashMap::new();
-        
+
         // Common dependencies
         deps.insert("sqlx".to_string(), format!(
             r#"{{ version = "0.7", features = ["{}", "runtime-tokio-native-tls", "chrono", "uuid"] }}"#,
             self.database_type
         ));
-        deps.insert("chrono".to_string(), r#"{ version = "0.4", features = ["serde"] }"#.to_string());
-        deps.insert("uuid".to_string(), r#"{ version = "1.0", features = ["v4", "serde"] }"#.to_string());
-        
+        deps.insert(
+            "chrono".to_string(),
+            r#"{ version = "0.4", features = ["serde"] }"#.to_string(),
+        );
+        deps.insert(
+            "uuid".to_string(),
+            r#"{ version = "1.0", features = ["v4", "serde"] }"#.to_string(),
+        );
+
         // Dev dependencies
-        deps.insert("sqlx-cli".to_string(), r#"{ version = "0.7", default-features = false, features = ["postgres"] }"#.to_string());
-        
+        deps.insert(
+            "sqlx-cli".to_string(),
+            r#"{ version = "0.7", default-features = false, features = ["postgres"] }"#.to_string(),
+        );
+
         deps
     }
 }
@@ -248,75 +275,75 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_postgres_db_module_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let db_module = generator.generate_db_module();
-        
+
         assert!(db_module.contains("use sqlx::{PgPool, Pool}"));
         assert!(db_module.contains("pub type DbPool = PgPool"));
         assert!(db_module.contains("PgPool::connect"));
         assert!(db_module.contains("DATABASE_URL"));
     }
-    
+
     #[test]
     fn test_mysql_db_module_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "mysql");
         let db_module = generator.generate_db_module();
-        
+
         assert!(db_module.contains("use sqlx::{MySqlPool, Pool}"));
         assert!(db_module.contains("pub type DbPool = MySqlPool"));
         assert!(db_module.contains("MySqlPool::connect"));
     }
-    
+
     #[test]
     fn test_sqlite_db_module_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "sqlite");
         let db_module = generator.generate_db_module();
-        
+
         assert!(db_module.contains("use sqlx::{SqlitePool, Pool}"));
         assert!(db_module.contains("pub type DbPool = SqlitePool"));
         assert!(db_module.contains("SqlitePool::connect"));
     }
-    
+
     #[test]
     fn test_postgres_migration_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let migration = generator.generate_migration_file(1, "create_users");
-        
+
         assert!(migration.contains("CREATE TABLE IF NOT EXISTS users"));
         assert!(migration.contains("SERIAL PRIMARY KEY"));
         assert!(migration.contains("TIMESTAMP WITH TIME ZONE"));
         assert!(migration.contains("CREATE OR REPLACE FUNCTION"));
         assert!(migration.contains("CREATE TRIGGER"));
     }
-    
+
     #[test]
     fn test_mysql_migration_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "mysql");
         let migration = generator.generate_migration_file(1, "create_users");
-        
+
         assert!(migration.contains("CREATE TABLE IF NOT EXISTS users"));
         assert!(migration.contains("INT AUTO_INCREMENT PRIMARY KEY"));
         assert!(migration.contains("ON UPDATE CURRENT_TIMESTAMP"));
     }
-    
+
     #[test]
     fn test_sqlite_migration_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "sqlite");
         let migration = generator.generate_migration_file(1, "create_users");
-        
+
         assert!(migration.contains("CREATE TABLE IF NOT EXISTS users"));
         assert!(migration.contains("INTEGER PRIMARY KEY AUTOINCREMENT"));
         assert!(migration.contains("CREATE TRIGGER update_users_updated_at"));
     }
-    
+
     #[test]
     fn test_models_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let models = generator.generate_models();
-        
+
         assert!(models.contains("use chrono::{DateTime, Utc}"));
         assert!(models.contains("#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]"));
         assert!(models.contains("pub struct User"));
@@ -324,15 +351,15 @@ mod tests {
         assert!(models.contains("pub async fn create"));
         assert!(models.contains("sqlx::query_as!"));
     }
-    
+
     #[test]
     fn test_file_structure_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let files = generator.generate_file_structure();
-        
+
         // Check that all expected files are generated
         let file_paths: Vec<String> = files.iter().map(|(path, _)| path.clone()).collect();
-        
+
         assert!(file_paths.contains(&"src/db.rs".to_string()));
         assert!(file_paths.contains(&"src/models.rs".to_string()));
         assert!(file_paths.contains(&"migrations/001_create_users.sql".to_string()));
@@ -340,55 +367,55 @@ mod tests {
         assert!(file_paths.contains(&"src/config/database.rs".to_string()));
         assert!(file_paths.contains(&"src/bin/migrate.rs".to_string()));
     }
-    
+
     #[test]
     fn test_database_config_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let config = generator.generate_database_config();
-        
+
         assert!(config.contains("pub struct DatabaseConfig"));
         assert!(config.contains("pub url: String"));
         assert!(config.contains("pub max_connections: u32"));
         assert!(config.contains("postgresql://localhost/my_app_dev"));
     }
-    
+
     #[test]
     fn test_migration_runner_generation() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let runner = generator.generate_migration_runner();
-        
+
         assert!(runner.contains("use sqlx::migrate::Migrator"));
         assert!(runner.contains("sqlx::PgPool::connect"));
         assert!(runner.contains("Migrator::new"));
         assert!(runner.contains("migrator.run(&pool)"));
     }
-    
+
     #[test]
     fn test_required_dependencies() {
         let generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         let deps = generator.get_required_dependencies();
-        
+
         assert!(deps.contains_key("sqlx"));
         assert!(deps.contains_key("chrono"));
         assert!(deps.contains_key("uuid"));
         assert!(deps.contains_key("sqlx-cli"));
-        
+
         let sqlx_dep = deps.get("sqlx").unwrap();
         assert!(sqlx_dep.contains("postgres"));
         assert!(sqlx_dep.contains("runtime-tokio-native-tls"));
     }
-    
+
     #[test]
     fn test_no_migrations_file_structure() {
         let mut generator = DatabaseFeatureGenerator::new("my_app", "postgres");
         generator.include_migrations = false;
-        
+
         let files = generator.generate_file_structure();
         let file_paths: Vec<String> = files.iter().map(|(path, _)| path.clone()).collect();
-        
+
         // Should not include migration files
         assert!(!file_paths.iter().any(|p| p.starts_with("migrations/")));
-        
+
         // But should still include other files
         assert!(file_paths.contains(&"src/db.rs".to_string()));
         assert!(file_paths.contains(&"src/models.rs".to_string()));

--- a/tests/e2e_comprehensive.rs
+++ b/tests/e2e_comprehensive.rs
@@ -12,6 +12,8 @@ fn create_test_config(name: &str, project_type: &str) -> ProjectConfig {
         author: "Test Author <test@example.com>".to_string(),
         description: Some(format!("Test {} project", project_type)),
         features: vec![],
+        target: None,
+        esp32_chip: None
     }
 }
 
@@ -154,6 +156,8 @@ fn test_comprehensive_project_matrix() {
             author: authors[i % authors.len()].to_string(),
             description: descriptions[i % descriptions.len()].clone(),
             features: vec![],
+            target: None,
+            esp32_chip: None
         };
 
         generator

--- a/tests/e2e_comprehensive.rs
+++ b/tests/e2e_comprehensive.rs
@@ -72,7 +72,7 @@ fn run_cargo_test(project_dir: &Path) -> Result<bool, String> {
 fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<(), String> {
     let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read file {:?}: {}", file_path, e))?;
-    
+
     for expected in expected_contents {
         if !content.contains(expected) {
             return Err(format!(
@@ -81,7 +81,7 @@ fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<
             ));
         }
     }
-    
+
     Ok(())
 }
 
@@ -89,7 +89,7 @@ fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<
 fn verify_file_not_contains(file_path: &Path, forbidden_contents: &[&str]) -> Result<(), String> {
     let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read file {:?}: {}", file_path, e))?;
-    
+
     for forbidden in forbidden_contents {
         if content.contains(forbidden) {
             return Err(format!(
@@ -98,7 +98,7 @@ fn verify_file_not_contains(file_path: &Path, forbidden_contents: &[&str]) -> Re
             ));
         }
     }
-    
+
     Ok(())
 }
 
@@ -121,33 +121,33 @@ fn test_comprehensive_project_matrix() {
     // Test ALL project types with different configurations
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
         "api-server",
         "cli-tool",
         "library",
         "wasm-app",
-        "game-engine", 
+        "game-engine",
         "embedded",
         "workspace",
     ];
-    
+
     let authors = vec![
         "John Doe <john@example.com>",
         "Jane Smith <jane@test.org>",
         "Bob Wilson <bob@dev.net>",
     ];
-    
+
     let descriptions = vec![
         Some("A test project for validation".to_string()),
         Some("Another test project".to_string()),
         None,
     ];
-    
+
     for (i, project_type) in project_types.iter().enumerate() {
         let project_name = format!("matrix-test-{}-{}", project_type, i);
         let project_dir = temp_dir.path().join(&project_name);
-        
+
         let config = ProjectConfig {
             name: project_name.clone(),
             project_type: project_type.to_string(),
@@ -155,10 +155,11 @@ fn test_comprehensive_project_matrix() {
             description: descriptions[i % descriptions.len()].clone(),
             features: vec![],
         };
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Verify the project compiles (skip embedded which needs special targets)
         if *project_type != "embedded" {
             match run_cargo_check(&project_dir) {
@@ -166,21 +167,23 @@ fn test_comprehensive_project_matrix() {
                 Err(e) => panic!("✗ {} project with config {} failed: {}", project_type, i, e),
             }
         } else {
-            println!("✓ {} project with config {} structure validated", project_type, i);
+            println!(
+                "✓ {} project with config {} structure validated",
+                project_type, i
+            );
         }
-        
+
         // Verify author is correctly set
         verify_file_contains(
             &project_dir.join("Cargo.toml"),
             &[authors[i % authors.len()]],
-        ).expect("Author verification failed");
-        
+        )
+        .expect("Author verification failed");
+
         // Verify description handling
         if let Some(desc) = &descriptions[i % descriptions.len()] {
-            verify_file_contains(
-                &project_dir.join("Cargo.toml"),
-                &[desc],
-            ).expect("Description verification failed");
+            verify_file_contains(&project_dir.join("Cargo.toml"), &[desc])
+                .expect("Description verification failed");
         }
     }
 }
@@ -190,32 +193,41 @@ fn test_project_dependency_verification() {
     // Test that each project type has the correct dependencies
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let dependency_tests = vec![
         ("api-server", vec!["axum", "tokio", "serde", "tower"]),
         ("cli-tool", vec!["clap", "anyhow", "env_logger"]),
         ("library", vec![]), // Library has no default dependencies
         ("wasm-app", vec!["wasm-bindgen", "web-sys", "js-sys"]),
-        ("game-engine", vec!["bevy", "wasm-bindgen", "web-sys", "console_error_panic_hook"]),
+        (
+            "game-engine",
+            vec![
+                "bevy",
+                "wasm-bindgen",
+                "web-sys",
+                "console_error_panic_hook",
+            ],
+        ),
         ("embedded", vec!["cortex-m", "cortex-m-rt", "panic-halt"]),
         ("workspace", vec![]), // Workspace has no root dependencies
     ];
-    
+
     for (project_type, expected_deps) in dependency_tests {
         let project_name = format!("dep-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         if !expected_deps.is_empty() {
-            verify_file_contains(
-                &project_dir.join("Cargo.toml"),
-                &expected_deps,
-            ).expect(&format!("Dependencies verification failed for {}", project_type));
+            verify_file_contains(&project_dir.join("Cargo.toml"), &expected_deps).expect(&format!(
+                "Dependencies verification failed for {}",
+                project_type
+            ));
         }
-        
+
         println!("✓ {} project has correct dependencies", project_type);
     }
 }
@@ -225,36 +237,94 @@ fn test_project_structure_validation() {
     // Test that each project type has the correct file structure
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let structure_tests = vec![
-        ("api-server", vec!["src/main.rs", "src/routes.rs", "src/handlers.rs", "src/models.rs", "config/default.toml", ".env.example"]),
-        ("cli-tool", vec!["src/main.rs", "src/cli.rs", "src/commands.rs"]),
+        (
+            "api-server",
+            vec![
+                "src/main.rs",
+                "src/routes.rs",
+                "src/handlers.rs",
+                "src/models.rs",
+                "config/default.toml",
+                ".env.example",
+            ],
+        ),
+        (
+            "cli-tool",
+            vec!["src/main.rs", "src/cli.rs", "src/commands.rs"],
+        ),
         ("library", vec!["src/lib.rs", "examples/basic.rs"]),
-        ("wasm-app", vec!["src/lib.rs", "index.html", "index.js", "package.json", "webpack.config.js", "build.sh"]),
-        ("game-engine", vec!["src/main.rs", "assets/README.md", "assets/models/", "assets/textures/", "assets/sounds/", "assets/shaders/", ".github/workflows/wasm.yml"]),
-        ("embedded", vec!["src/main.rs", ".cargo/config.toml", "memory.x", "Embed.toml"]),
-        ("workspace", vec!["crates/core/src/lib.rs", "crates/api/src/lib.rs", "crates/cli/src/main.rs", "crates/core/Cargo.toml", "crates/api/Cargo.toml", "crates/cli/Cargo.toml"]),
+        (
+            "wasm-app",
+            vec![
+                "src/lib.rs",
+                "index.html",
+                "index.js",
+                "package.json",
+                "webpack.config.js",
+                "build.sh",
+            ],
+        ),
+        (
+            "game-engine",
+            vec![
+                "src/main.rs",
+                "assets/README.md",
+                "assets/models/",
+                "assets/textures/",
+                "assets/sounds/",
+                "assets/shaders/",
+                ".github/workflows/wasm.yml",
+            ],
+        ),
+        (
+            "embedded",
+            vec![
+                "src/main.rs",
+                ".cargo/config.toml",
+                "memory.x",
+                "Embed.toml",
+            ],
+        ),
+        (
+            "workspace",
+            vec![
+                "crates/core/src/lib.rs",
+                "crates/api/src/lib.rs",
+                "crates/cli/src/main.rs",
+                "crates/core/Cargo.toml",
+                "crates/api/Cargo.toml",
+                "crates/cli/Cargo.toml",
+            ],
+        ),
     ];
-    
+
     for (project_type, expected_files) in structure_tests {
         let project_name = format!("struct-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         for file in expected_files {
             let file_path = project_dir.join(file);
-            assert!(file_path.exists(), "{} project should have {}", project_type, file);
-            
+            assert!(
+                file_path.exists(),
+                "{} project should have {}",
+                project_type,
+                file
+            );
+
             if file.ends_with('/') {
                 assert!(file_path.is_dir(), "{} should be a directory", file);
             } else {
                 assert!(file_path.is_file(), "{} should be a file", file);
             }
         }
-        
+
         println!("✓ {} project has correct structure", project_type);
     }
 }
@@ -264,38 +334,59 @@ fn test_gitignore_correctness() {
     // Test that .gitignore files are appropriate for each project type
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let gitignore_tests = vec![
         ("api-server", vec!["/target"], vec![]),
         ("cli-tool", vec!["/target"], vec!["Cargo.lock"]),
         ("library", vec!["/target", "Cargo.lock"], vec![]),
-        ("wasm-app", vec!["/target", "node_modules", "dist/", "pkg/"], vec!["Cargo.lock"]),
-        ("game-engine", vec!["/target", "wasm/", "*.wasm", ".DS_Store"], vec!["Cargo.lock"]),
-        ("embedded", vec!["/target", "*.bin", "*.hex", "*.elf", ".vscode/"], vec!["Cargo.lock"]),
+        (
+            "wasm-app",
+            vec!["/target", "node_modules", "dist/", "pkg/"],
+            vec!["Cargo.lock"],
+        ),
+        (
+            "game-engine",
+            vec!["/target", "wasm/", "*.wasm", ".DS_Store"],
+            vec!["Cargo.lock"],
+        ),
+        (
+            "embedded",
+            vec!["/target", "*.bin", "*.hex", "*.elf", ".vscode/"],
+            vec!["Cargo.lock"],
+        ),
         ("workspace", vec!["/target", "Cargo.lock"], vec![]),
     ];
-    
+
     for (project_type, must_have, must_not_have) in gitignore_tests {
         let project_name = format!("gitignore-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         let gitignore_path = project_dir.join(".gitignore");
-        assert!(gitignore_path.exists(), "{} should have .gitignore", project_type);
-        
+        assert!(
+            gitignore_path.exists(),
+            "{} should have .gitignore",
+            project_type
+        );
+
         // Verify required entries
-        verify_file_contains(&gitignore_path, &must_have)
-            .expect(&format!(".gitignore verification failed for {}", project_type));
-        
+        verify_file_contains(&gitignore_path, &must_have).expect(&format!(
+            ".gitignore verification failed for {}",
+            project_type
+        ));
+
         // Verify forbidden entries
         if !must_not_have.is_empty() {
-            verify_file_not_contains(&gitignore_path, &must_not_have)
-                .expect(&format!(".gitignore should not contain forbidden entries for {}", project_type));
+            verify_file_not_contains(&gitignore_path, &must_not_have).expect(&format!(
+                ".gitignore should not contain forbidden entries for {}",
+                project_type
+            ));
         }
-        
+
         println!("✓ {} project has correct .gitignore", project_type);
     }
 }
@@ -305,37 +396,65 @@ fn test_readme_quality() {
     // Test that README files are comprehensive and helpful
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
-        "api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("readme-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         let readme_path = project_dir.join("README.md");
-        assert!(readme_path.exists(), "{} should have README.md", project_type);
-        
+        assert!(
+            readme_path.exists(),
+            "{} should have README.md",
+            project_type
+        );
+
         // Verify basic structure
-        verify_file_contains(&readme_path, &[
-            &format!("# {}", project_name),
-            &format!("Test {} project", project_type),
-        ]).expect(&format!("README basic structure failed for {}", project_type));
-        
+        verify_file_contains(
+            &readme_path,
+            &[
+                &format!("# {}", project_name),
+                &format!("Test {} project", project_type),
+            ],
+        )
+        .expect(&format!(
+            "README basic structure failed for {}",
+            project_type
+        ));
+
         // Verify README has reasonable content
-        let line_count = count_lines(&readme_path)
-            .expect(&format!("Failed to count lines in README for {}", project_type));
-        assert!(line_count > 10, "{} README should have substantial content", project_type);
-        
+        let line_count = count_lines(&readme_path).expect(&format!(
+            "Failed to count lines in README for {}",
+            project_type
+        ));
+        assert!(
+            line_count > 10,
+            "{} README should have substantial content",
+            project_type
+        );
+
         let file_size = get_file_size(&readme_path)
             .expect(&format!("Failed to get README size for {}", project_type));
-        assert!(file_size > 100, "{} README should have reasonable size", project_type);
-        
+        assert!(
+            file_size > 100,
+            "{} README should have reasonable size",
+            project_type
+        );
+
         println!("✓ {} project has quality README", project_type);
     }
 }
@@ -345,33 +464,41 @@ fn test_cargo_toml_quality() {
     // Test that Cargo.toml files are well-formed and complete
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
-        "api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("cargo-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         let cargo_toml_path = project_dir.join("Cargo.toml");
-        assert!(cargo_toml_path.exists(), "{} should have Cargo.toml", project_type);
-        
+        assert!(
+            cargo_toml_path.exists(),
+            "{} should have Cargo.toml",
+            project_type
+        );
+
         // Verify basic metadata
-        let required_fields = vec![
-            "name =",
-            "version =",
-            "edition =",
-            "authors =",
-        ];
-        
-        verify_file_contains(&cargo_toml_path, &required_fields)
-            .expect(&format!("Cargo.toml basic fields failed for {}", project_type));
-        
+        let required_fields = vec!["name =", "version =", "edition =", "authors ="];
+
+        verify_file_contains(&cargo_toml_path, &required_fields).expect(&format!(
+            "Cargo.toml basic fields failed for {}",
+            project_type
+        ));
+
         // Verify project-specific configuration
         match project_type {
             "cli-tool" => {
@@ -396,7 +523,7 @@ fn test_cargo_toml_quality() {
             }
             _ => {}
         }
-        
+
         println!("✓ {} project has quality Cargo.toml", project_type);
     }
 }
@@ -406,19 +533,26 @@ fn test_project_compilation_modes() {
     // Test that projects compile in different modes
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
-        "api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("compile-modes-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Test cargo check (skip for embedded which needs special targets)
         if project_type != "embedded" {
             match run_cargo_check(&project_dir) {
@@ -426,9 +560,12 @@ fn test_project_compilation_modes() {
                 Err(e) => panic!("✗ {} project fails cargo check: {}", project_type, e),
             }
         } else {
-            println!("✓ {} project structure validated (check requires embedded target)", project_type);
+            println!(
+                "✓ {} project structure validated (check requires embedded target)",
+                project_type
+            );
         }
-        
+
         // Test cargo build (skip for embedded and wasm which need special setup)
         if !matches!(project_type, "embedded" | "wasm-app") {
             match run_cargo_build(&project_dir) {
@@ -436,9 +573,12 @@ fn test_project_compilation_modes() {
                 Err(e) => panic!("✗ {} project fails to build: {}", project_type, e),
             }
         } else {
-            println!("✓ {} project generation completed (build requires special setup)", project_type);
+            println!(
+                "✓ {} project generation completed (build requires special setup)",
+                project_type
+            );
         }
-        
+
         // Test cargo test (skip for embedded and wasm which may need special setup)
         if !matches!(project_type, "embedded" | "wasm-app") {
             match run_cargo_test(&project_dir) {
@@ -454,7 +594,7 @@ fn test_project_name_edge_cases() {
     // Test project generation with various name formats
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let name_tests = vec![
         ("simple-name", "library"),
         ("name_with_underscores", "library"),
@@ -462,35 +602,43 @@ fn test_project_name_edge_cases() {
         ("name123with456numbers", "library"),
         ("very-long-project-name-that-should-still-work", "library"),
         ("a", "library"), // Single character
-        ("project_name_with_multiple_underscores_and_hyphens", "library"),
+        (
+            "project_name_with_multiple_underscores_and_hyphens",
+            "library",
+        ),
     ];
-    
+
     for (project_name, project_type) in name_tests {
         let project_dir = temp_dir.path().join(project_name);
         let config = create_test_config(project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
-            .expect(&format!("Failed to generate project with name '{}'", project_name));
-        
+
+        generator.generate(&config, &project_dir).expect(&format!(
+            "Failed to generate project with name '{}'",
+            project_name
+        ));
+
         // Verify the project compiles
         match run_cargo_check(&project_dir) {
             Ok(_) => println!("✓ Project with name '{}' compiles", project_name),
             Err(e) => panic!("✗ Project with name '{}' failed: {}", project_name, e),
         }
-        
+
         // Verify name is correctly set in Cargo.toml
         let cargo_toml_path = project_dir.join("Cargo.toml");
-        let content = fs::read_to_string(&cargo_toml_path)
-            .expect("Failed to read Cargo.toml");
-        
+        let content = fs::read_to_string(&cargo_toml_path).expect("Failed to read Cargo.toml");
+
         // For libraries, name might be converted (hyphens to underscores)
         if project_type == "library" {
             let expected_lib_name = project_name.replace('-', "_");
-            assert!(content.contains(&expected_lib_name) || content.contains(project_name),
-                "Library name should be properly handled in Cargo.toml");
+            assert!(
+                content.contains(&expected_lib_name) || content.contains(project_name),
+                "Library name should be properly handled in Cargo.toml"
+            );
         } else {
-            assert!(content.contains(project_name),
-                "Project name should be in Cargo.toml");
+            assert!(
+                content.contains(project_name),
+                "Project name should be in Cargo.toml"
+            );
         }
     }
 }
@@ -500,19 +648,26 @@ fn test_cross_platform_compatibility() {
     // Test that generated projects work across different platforms
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
-        "api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("cross-platform-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Test that all files use correct line endings and are readable
         let files_to_check = vec!["Cargo.toml", "README.md", ".gitignore"];
         for file in files_to_check {
@@ -520,16 +675,24 @@ fn test_cross_platform_compatibility() {
             if file_path.exists() {
                 let content = fs::read_to_string(&file_path)
                     .expect(&format!("Should be able to read {}", file));
-                
+
                 // Verify file is not empty and has reasonable content
                 assert!(!content.is_empty(), "{} should not be empty", file);
-                assert!(content.len() > 10, "{} should have reasonable content", file);
-                
+                assert!(
+                    content.len() > 10,
+                    "{} should have reasonable content",
+                    file
+                );
+
                 // Verify file doesn't have obvious encoding issues
-                assert!(!content.contains('\0'), "{} should not contain null bytes", file);
+                assert!(
+                    !content.contains('\0'),
+                    "{} should not contain null bytes",
+                    file
+                );
             }
         }
-        
+
         println!("✓ {} project is cross-platform compatible", project_type);
     }
 }
@@ -539,33 +702,44 @@ fn test_project_generation_stress() {
     // Stress test by generating many projects quickly
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
-        "api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
     ];
-    
+
     let num_iterations = 50;
     let start_time = std::time::Instant::now();
-    
+
     for i in 0..num_iterations {
         let project_type = &project_types[i % project_types.len()];
         let project_name = format!("stress-test-{}-{}", project_type, i);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
-            .expect(&format!("Failed to generate {} project in stress test", project_type));
-        
+
+        generator.generate(&config, &project_dir).expect(&format!(
+            "Failed to generate {} project in stress test",
+            project_type
+        ));
+
         // Quick verification
         assert!(project_dir.join("Cargo.toml").exists());
         assert!(project_dir.join("README.md").exists());
         assert!(project_dir.join(".gitignore").exists());
     }
-    
+
     let elapsed = start_time.elapsed();
     println!("✓ Generated {} projects in {:?}", num_iterations, elapsed);
-    
+
     // Verify performance is reasonable
     let avg_time = elapsed.as_millis() / num_iterations as u128;
-    assert!(avg_time < 1000, "Average project generation time should be under 1 second");
+    assert!(
+        avg_time < 1000,
+        "Average project generation time should be under 1 second"
+    );
 }

--- a/tests/e2e_feature_integration.rs
+++ b/tests/e2e_feature_integration.rs
@@ -11,6 +11,8 @@ fn create_test_config(name: &str, project_type: &str) -> ProjectConfig {
         project_type: project_type.to_string(),
         author: "Test Author <test@example.com>".to_string(),
         description: Some(format!("Test {} project", project_type)),
+        esp32_chip: None,
+        target: None,
         features: vec![],
     }
 }
@@ -121,6 +123,8 @@ impl ExtendedProjectConfig {
             project_type: self.project_type.clone(),
             author: self.author.clone(),
             description: self.description.clone(),
+            esp32_chip: None,
+            target: None,
             features: self.features.clone(),
         }
     }

--- a/tests/e2e_feature_integration.rs
+++ b/tests/e2e_feature_integration.rs
@@ -40,7 +40,7 @@ fn run_cargo_check(project_dir: &Path) -> Result<bool, String> {
 fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<(), String> {
     let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read file {:?}: {}", file_path, e))?;
-    
+
     for expected in expected_contents {
         if !content.contains(expected) {
             return Err(format!(
@@ -49,7 +49,7 @@ fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<
             ));
         }
     }
-    
+
     Ok(())
 }
 
@@ -83,37 +83,37 @@ impl ExtendedProjectConfig {
             testing_framework: None,
         }
     }
-    
+
     pub fn with_feature(mut self, feature: &str) -> Self {
         self.features.push(feature.to_string());
         self
     }
-    
+
     pub fn with_database(mut self, db: &str) -> Self {
         self.database = Some(db.to_string());
         self
     }
-    
+
     pub fn with_auth(mut self, auth: &str) -> Self {
         self.auth_type = Some(auth.to_string());
         self
     }
-    
+
     pub fn with_ci(mut self, ci: &str) -> Self {
         self.ci_provider = Some(ci.to_string());
         self
     }
-    
+
     pub fn with_docker(mut self) -> Self {
         self.docker = true;
         self
     }
-    
+
     pub fn with_testing(mut self, framework: &str) -> Self {
         self.testing_framework = Some(framework.to_string());
         self
     }
-    
+
     // Convert to basic ProjectConfig for now
     pub fn to_basic_config(&self) -> ProjectConfig {
         ProjectConfig {
@@ -131,66 +131,112 @@ fn test_basic_project_types_with_default_features() {
     // Test that all project types work with their default feature sets
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
         "api-server",
         "cli-tool",
-        "library", 
+        "library",
         "wasm-app",
         "game-engine",
         "embedded",
         "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("basic-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Verify default dependencies are included
         let cargo_toml_path = project_dir.join("Cargo.toml");
-        let cargo_content = fs::read_to_string(&cargo_toml_path)
-            .expect("Failed to read Cargo.toml");
-        
+        let cargo_content =
+            fs::read_to_string(&cargo_toml_path).expect("Failed to read Cargo.toml");
+
         match project_type {
             "api-server" => {
-                assert!(cargo_content.contains("axum"), "API server should have axum");
-                assert!(cargo_content.contains("tokio"), "API server should have tokio");
-                assert!(cargo_content.contains("serde"), "API server should have serde");
-                assert!(cargo_content.contains("tower"), "API server should have tower");
+                assert!(
+                    cargo_content.contains("axum"),
+                    "API server should have axum"
+                );
+                assert!(
+                    cargo_content.contains("tokio"),
+                    "API server should have tokio"
+                );
+                assert!(
+                    cargo_content.contains("serde"),
+                    "API server should have serde"
+                );
+                assert!(
+                    cargo_content.contains("tower"),
+                    "API server should have tower"
+                );
             }
             "cli-tool" => {
                 assert!(cargo_content.contains("clap"), "CLI tool should have clap");
-                assert!(cargo_content.contains("anyhow"), "CLI tool should have anyhow");
-                assert!(cargo_content.contains("env_logger"), "CLI tool should have env_logger");
+                assert!(
+                    cargo_content.contains("anyhow"),
+                    "CLI tool should have anyhow"
+                );
+                assert!(
+                    cargo_content.contains("env_logger"),
+                    "CLI tool should have env_logger"
+                );
             }
             "wasm-app" => {
-                assert!(cargo_content.contains("wasm-bindgen"), "WASM app should have wasm-bindgen");
-                assert!(cargo_content.contains("web-sys"), "WASM app should have web-sys");
-                assert!(cargo_content.contains("js-sys"), "WASM app should have js-sys");
+                assert!(
+                    cargo_content.contains("wasm-bindgen"),
+                    "WASM app should have wasm-bindgen"
+                );
+                assert!(
+                    cargo_content.contains("web-sys"),
+                    "WASM app should have web-sys"
+                );
+                assert!(
+                    cargo_content.contains("js-sys"),
+                    "WASM app should have js-sys"
+                );
             }
             "game-engine" => {
-                assert!(cargo_content.contains("bevy"), "Game engine should have bevy");
+                assert!(
+                    cargo_content.contains("bevy"),
+                    "Game engine should have bevy"
+                );
             }
             "embedded" => {
-                assert!(cargo_content.contains("cortex-m"), "Embedded should have cortex-m");
-                assert!(cargo_content.contains("cortex-m-rt"), "Embedded should have cortex-m-rt");
-                assert!(cargo_content.contains("panic-halt"), "Embedded should have panic-halt");
+                assert!(
+                    cargo_content.contains("cortex-m"),
+                    "Embedded should have cortex-m"
+                );
+                assert!(
+                    cargo_content.contains("cortex-m-rt"),
+                    "Embedded should have cortex-m-rt"
+                );
+                assert!(
+                    cargo_content.contains("panic-halt"),
+                    "Embedded should have panic-halt"
+                );
             }
             _ => {} // Library and workspace don't have specific dependencies
         }
-        
+
         // Verify project compiles (skip embedded which needs special targets)
         if project_type != "embedded" {
             match run_cargo_check(&project_dir) {
                 Ok(_) => println!("✓ {} project with default features compiles", project_type),
-                Err(e) => panic!("✗ {} project with default features failed: {}", project_type, e),
+                Err(e) => panic!(
+                    "✗ {} project with default features failed: {}",
+                    project_type, e
+                ),
             }
         } else {
-            println!("✓ {} project structure validated (compilation requires embedded target)", project_type);
+            println!(
+                "✓ {} project structure validated (compilation requires embedded target)",
+                project_type
+            );
         }
     }
 }
@@ -200,35 +246,64 @@ fn test_template_feature_conditional_rendering() {
     // Test how the current template system handles conditional content
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     // Test API server project - should have specific structure
     let api_project_dir = temp_dir.path().join("test-api-features");
     let api_config = create_test_config("test-api-features", "api-server");
-    
-    generator.generate(&api_config, &api_project_dir)
+
+    generator
+        .generate(&api_config, &api_project_dir)
         .expect("Failed to generate API server project");
-    
+
     // Verify API server specific files exist
-    assert!(api_project_dir.join("src/routes.rs").exists(), "API server should have routes.rs");
-    assert!(api_project_dir.join("src/handlers.rs").exists(), "API server should have handlers.rs");
-    assert!(api_project_dir.join("src/models.rs").exists(), "API server should have models.rs");
-    assert!(api_project_dir.join("config/default.toml").exists(), "API server should have config");
-    assert!(api_project_dir.join(".env.example").exists(), "API server should have .env.example");
-    
+    assert!(
+        api_project_dir.join("src/routes.rs").exists(),
+        "API server should have routes.rs"
+    );
+    assert!(
+        api_project_dir.join("src/handlers.rs").exists(),
+        "API server should have handlers.rs"
+    );
+    assert!(
+        api_project_dir.join("src/models.rs").exists(),
+        "API server should have models.rs"
+    );
+    assert!(
+        api_project_dir.join("config/default.toml").exists(),
+        "API server should have config"
+    );
+    assert!(
+        api_project_dir.join(".env.example").exists(),
+        "API server should have .env.example"
+    );
+
     // Test CLI tool project - should have different structure
     let cli_project_dir = temp_dir.path().join("test-cli-features");
     let cli_config = create_test_config("test-cli-features", "cli-tool");
-    
-    generator.generate(&cli_config, &cli_project_dir)
+
+    generator
+        .generate(&cli_config, &cli_project_dir)
         .expect("Failed to generate CLI tool project");
-    
+
     // Verify CLI tool specific files exist
-    assert!(cli_project_dir.join("src/cli.rs").exists(), "CLI tool should have cli.rs");
-    assert!(cli_project_dir.join("src/commands.rs").exists(), "CLI tool should have commands.rs");
-    
+    assert!(
+        cli_project_dir.join("src/cli.rs").exists(),
+        "CLI tool should have cli.rs"
+    );
+    assert!(
+        cli_project_dir.join("src/commands.rs").exists(),
+        "CLI tool should have commands.rs"
+    );
+
     // Verify CLI tool doesn't have API server files
-    assert!(!cli_project_dir.join("src/routes.rs").exists(), "CLI tool should not have routes.rs");
-    assert!(!cli_project_dir.join("config/default.toml").exists(), "CLI tool should not have config");
+    assert!(
+        !cli_project_dir.join("src/routes.rs").exists(),
+        "CLI tool should not have routes.rs"
+    );
+    assert!(
+        !cli_project_dir.join("config/default.toml").exists(),
+        "CLI tool should not have config"
+    );
 }
 
 #[test]
@@ -236,52 +311,60 @@ fn test_project_type_specific_configurations() {
     // Test that each project type has appropriate configurations
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     // Test library configuration
     let lib_project_dir = temp_dir.path().join("test-lib-config");
     let lib_config = create_test_config("test-lib-config", "library");
-    
-    generator.generate(&lib_config, &lib_project_dir)
+
+    generator
+        .generate(&lib_config, &lib_project_dir)
         .expect("Failed to generate library project");
-    
+
     verify_file_contains(
         &lib_project_dir.join("Cargo.toml"),
         &["[lib]", "test_lib_config"], // Note: hyphens converted to underscores
-    ).expect("Library should have lib configuration");
-    
+    )
+    .expect("Library should have lib configuration");
+
     verify_file_contains(
         &lib_project_dir.join(".gitignore"),
         &["Cargo.lock"], // Libraries should ignore Cargo.lock
-    ).expect("Library should ignore Cargo.lock");
-    
+    )
+    .expect("Library should ignore Cargo.lock");
+
     // Test CLI tool binary configuration
     let cli_project_dir = temp_dir.path().join("test-cli-config");
     let cli_config = create_test_config("test-cli-config", "cli-tool");
-    
-    generator.generate(&cli_config, &cli_project_dir)
+
+    generator
+        .generate(&cli_config, &cli_project_dir)
         .expect("Failed to generate CLI tool project");
-    
+
     verify_file_contains(
         &cli_project_dir.join("Cargo.toml"),
         &["[[bin]]", "path = \"src/main.rs\""],
-    ).expect("CLI tool should have bin configuration");
-    
+    )
+    .expect("CLI tool should have bin configuration");
+
     // Test WASM app library configuration
     let wasm_project_dir = temp_dir.path().join("test-wasm-config");
     let wasm_config = create_test_config("test-wasm-config", "wasm-app");
-    
-    generator.generate(&wasm_config, &wasm_project_dir)
+
+    generator
+        .generate(&wasm_config, &wasm_project_dir)
         .expect("Failed to generate WASM app project");
-    
+
     verify_file_contains(
         &wasm_project_dir.join("Cargo.toml"),
         &["[lib]", r#"crate-type = ["cdylib"]"#],
-    ).expect("WASM app should have cdylib configuration");
-    
+    )
+    .expect("WASM app should have cdylib configuration");
+
     verify_file_contains(
         &wasm_project_dir.join(".gitignore"),
         &["node_modules", "dist/", "pkg/"],
-    ).expect("WASM app should ignore Node.js and build artifacts");
+    )
+    .expect("WASM app should ignore Node.js and build artifacts");
 }
 
 #[test]
@@ -289,37 +372,42 @@ fn test_cross_project_type_compatibility() {
     // Test that different project types can coexist and don't interfere
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
-    let project_types = vec![
-        "api-server",
-        "cli-tool",
-        "library",
-        "wasm-app",
-    ];
-    
+
+    let project_types = vec!["api-server", "cli-tool", "library", "wasm-app"];
+
     let mut project_dirs = Vec::new();
-    
+
     // Generate all project types in the same temp directory
     for project_type in &project_types {
         let project_name = format!("compat-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         project_dirs.push((project_type, project_dir));
     }
-    
+
     // Verify all projects can be checked simultaneously (skip embedded)
     for (project_type, project_dir) in project_dirs {
         if project_type != &"embedded" {
             match run_cargo_check(&project_dir) {
-                Ok(_) => println!("✓ {} project compiles in multi-project environment", project_type),
-                Err(e) => panic!("✗ {} project failed in multi-project environment: {}", project_type, e),
+                Ok(_) => println!(
+                    "✓ {} project compiles in multi-project environment",
+                    project_type
+                ),
+                Err(e) => panic!(
+                    "✗ {} project failed in multi-project environment: {}",
+                    project_type, e
+                ),
             }
         } else {
-            println!("✓ {} project structure validated in multi-project environment", project_type);
+            println!(
+                "✓ {} project structure validated in multi-project environment",
+                project_type
+            );
         }
     }
 }
@@ -327,43 +415,41 @@ fn test_cross_project_type_compatibility() {
 #[test]
 fn test_future_feature_system_design() {
     // This test documents and validates the design for a future feature system
-    
+
     // Example of how an extended feature system could work
     let extended_configs = vec![
         ExtendedProjectConfig::new("api-with-db", "api-server")
             .with_database("postgresql")
             .with_auth("jwt")
             .with_docker(),
-            
         ExtendedProjectConfig::new("cli-with-config", "cli-tool")
             .with_feature("config-file")
             .with_testing("integration"),
-            
         ExtendedProjectConfig::new("lib-with-async", "library")
             .with_feature("async")
             .with_ci("github-actions"),
-            
         ExtendedProjectConfig::new("wasm-with-workers", "wasm-app")
             .with_feature("web-workers")
             .with_testing("wasm-pack-test"),
     ];
-    
+
     // For now, validate that the basic configs still work
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     for extended_config in extended_configs {
         let basic_config = extended_config.to_basic_config();
         let project_dir = temp_dir.path().join(&basic_config.name);
-        
-        generator.generate(&basic_config, &project_dir)
+
+        generator
+            .generate(&basic_config, &project_dir)
             .expect(&format!("Failed to generate {} project", basic_config.name));
-        
+
         // Validate that basic structure is created
         assert!(project_dir.join("Cargo.toml").exists());
         assert!(project_dir.join("README.md").exists());
         assert!(project_dir.join(".gitignore").exists());
-        
+
         // Document what additional features would be added
         match extended_config.project_type.as_str() {
             "api-server" => {
@@ -381,7 +467,10 @@ fn test_future_feature_system_design() {
                 }
             }
             "cli-tool" => {
-                if extended_config.features.contains(&"config-file".to_string()) {
+                if extended_config
+                    .features
+                    .contains(&"config-file".to_string())
+                {
                     // Future: Should add config file handling
                     println!("Future: Would add config file handling");
                 }
@@ -393,22 +482,31 @@ fn test_future_feature_system_design() {
                 }
             }
             "wasm-app" => {
-                if extended_config.features.contains(&"web-workers".to_string()) {
+                if extended_config
+                    .features
+                    .contains(&"web-workers".to_string())
+                {
                     // Future: Should add web workers setup
                     println!("Future: Would add web workers configuration");
                 }
             }
             _ => {}
         }
-        
+
         // Verify current project compiles (skip embedded)
         if extended_config.project_type != "embedded" {
             match run_cargo_check(&project_dir) {
-                Ok(_) => println!("✓ Extended config {} compiles with basic features", extended_config.name),
+                Ok(_) => println!(
+                    "✓ Extended config {} compiles with basic features",
+                    extended_config.name
+                ),
                 Err(e) => panic!("✗ Extended config {} failed: {}", extended_config.name, e),
             }
         } else {
-            println!("✓ Extended config {} structure validated", extended_config.name);
+            println!(
+                "✓ Extended config {} structure validated",
+                extended_config.name
+            );
         }
     }
 }
@@ -418,7 +516,7 @@ fn test_template_system_extensibility() {
     // Test that the current template system could be extended for features
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     // Test that we can generate multiple variations of the same project type
     let variations = vec![
         ("minimal-api", "api-server"),
@@ -426,17 +524,18 @@ fn test_template_system_extensibility() {
         ("simple-cli", "cli-tool"),
         ("advanced-cli", "cli-tool"),
     ];
-    
+
     for (project_name, project_type) in variations {
         let project_dir = temp_dir.path().join(project_name);
         let config = create_test_config(project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_name));
-        
+
         // All variations should currently produce the same output
         // But in the future, they could produce different feature sets
-        
+
         if !project_type.contains("embedded") {
             match run_cargo_check(&project_dir) {
                 Ok(_) => println!("✓ {} variation compiles", project_name),
@@ -453,7 +552,7 @@ fn test_dependency_management_patterns() {
     // Test how dependencies are managed across project types
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
         ("api-server", vec!["axum", "tokio", "serde", "tower"]),
         ("cli-tool", vec!["clap", "anyhow", "env_logger"]),
@@ -461,31 +560,38 @@ fn test_dependency_management_patterns() {
         ("game-engine", vec!["bevy"]),
         ("embedded", vec!["cortex-m", "cortex-m-rt", "panic-halt"]),
     ];
-    
+
     for (project_type, expected_deps) in project_types {
         let project_name = format!("deps-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         let cargo_toml_path = project_dir.join("Cargo.toml");
-        
+
         // Verify all expected dependencies are present
         for dep in expected_deps {
             verify_file_contains(&cargo_toml_path, &[dep])
                 .expect(&format!("{} should have {} dependency", project_type, dep));
         }
-        
+
         // Verify project compiles with these dependencies (skip embedded)
         if project_type != "embedded" {
             match run_cargo_check(&project_dir) {
                 Ok(_) => println!("✓ {} with standard dependencies compiles", project_type),
-                Err(e) => panic!("✗ {} with standard dependencies failed: {}", project_type, e),
+                Err(e) => panic!(
+                    "✗ {} with standard dependencies failed: {}",
+                    project_type, e
+                ),
             }
         } else {
-            println!("✓ {} with standard dependencies structure validated", project_type);
+            println!(
+                "✓ {} with standard dependencies structure validated",
+                project_type
+            );
         }
     }
 }

--- a/tests/e2e_feature_matrix.rs
+++ b/tests/e2e_feature_matrix.rs
@@ -527,6 +527,8 @@ impl FeatureMatrixTestSuite {
             project_type: config.project_type.clone(),
             author: config.author.clone(),
             description: config.description.clone(),
+            esp32_chip: None,
+            target: None,
             features: config.features.clone(),
         };
 

--- a/tests/e2e_feature_matrix.rs
+++ b/tests/e2e_feature_matrix.rs
@@ -1,9 +1,9 @@
 use cargo_forge::{Generator, ProjectConfig};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-use std::collections::HashMap;
 
 /// Feature matrix testing for comprehensive validation of project generation
 /// This module tests various combinations of project configurations, edge cases,
@@ -41,7 +41,7 @@ pub enum ValidationRule {
     CargoTestPasses,
     DirectoryExists(String),
     FileExecutable(String),
-    FileSize(String, u64, u64), // file, min_size, max_size
+    FileSize(String, u64, u64),      // file, min_size, max_size
     LineCount(String, usize, usize), // file, min_lines, max_lines
 }
 
@@ -135,7 +135,10 @@ impl FeatureMatrixTestSuite {
                 test_category: "Author Variations".to_string(),
                 expected_behavior: TestExpectation::Success,
                 validation_rules: vec![
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "authors = [\"Simple Name\"]".to_string()),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "authors = [\"Simple Name\"]".to_string(),
+                    ),
                     ValidationRule::CargoCheckPasses,
                 ],
             },
@@ -148,7 +151,10 @@ impl FeatureMatrixTestSuite {
                 test_category: "Author Variations".to_string(),
                 expected_behavior: TestExpectation::Success,
                 validation_rules: vec![
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "authors = [\"John Doe <john@example.com>\"]".to_string()),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "authors = [\"John Doe <john@example.com>\"]".to_string(),
+                    ),
                     ValidationRule::CargoCheckPasses,
                 ],
             },
@@ -161,7 +167,10 @@ impl FeatureMatrixTestSuite {
                 test_category: "Author Variations".to_string(),
                 expected_behavior: TestExpectation::Success,
                 validation_rules: vec![
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "José García".to_string()),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "José García".to_string(),
+                    ),
                     ValidationRule::CargoCheckPasses,
                 ],
             },
@@ -270,8 +279,14 @@ impl FeatureMatrixTestSuite {
                     ValidationRule::FileExists("webpack.config.js".to_string()),
                     ValidationRule::FileExists("build.sh".to_string()),
                     ValidationRule::FileExecutable("build.sh".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "wasm-bindgen".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "crate-type = [\"cdylib\"]".to_string()),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "wasm-bindgen".to_string(),
+                    ),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "crate-type = [\"cdylib\"]".to_string(),
+                    ),
                     ValidationRule::CargoCheckPasses,
                 ],
             },
@@ -291,8 +306,14 @@ impl FeatureMatrixTestSuite {
                     ValidationRule::FileExists("README.md".to_string()),
                     ValidationRule::FileSize("README.md".to_string(), 100, 10000),
                     ValidationRule::LineCount("README.md".to_string(), 10, 100),
-                    ValidationRule::FileContains("README.md".to_string(), "# readme-quality".to_string()),
-                    ValidationRule::FileContains("README.md".to_string(), "Testing README quality".to_string()),
+                    ValidationRule::FileContains(
+                        "README.md".to_string(),
+                        "# readme-quality".to_string(),
+                    ),
+                    ValidationRule::FileContains(
+                        "README.md".to_string(),
+                        "Testing README quality".to_string(),
+                    ),
                     ValidationRule::CargoCheckPasses,
                 ],
             },
@@ -306,10 +327,22 @@ impl FeatureMatrixTestSuite {
                 expected_behavior: TestExpectation::Success,
                 validation_rules: vec![
                     ValidationRule::FileExists("Cargo.toml".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "[workspace]".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "[workspace.package]".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "[workspace.dependencies]".to_string()),
-                    ValidationRule::FileContains("Cargo.toml".to_string(), "members = [".to_string()),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "[workspace]".to_string(),
+                    ),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "[workspace.package]".to_string(),
+                    ),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "[workspace.dependencies]".to_string(),
+                    ),
+                    ValidationRule::FileContains(
+                        "Cargo.toml".to_string(),
+                        "members = [".to_string(),
+                    ),
                     ValidationRule::FileSize("Cargo.toml".to_string(), 100, 5000),
                     ValidationRule::CargoCheckPasses,
                 ],
@@ -317,27 +350,25 @@ impl FeatureMatrixTestSuite {
         ]);
 
         // Cross-platform compatibility tests
-        matrix.extend(vec![
-            MatrixTestConfig {
-                name: "cross-platform-paths".to_string(),
-                project_type: "game-engine".to_string(),
-                author: "Cross Platform <cross@example.com>".to_string(),
-                description: Some("Testing cross-platform path handling".to_string()),
-                features: vec![],
-                test_category: "Cross-Platform".to_string(),
-                expected_behavior: TestExpectation::Success,
-                validation_rules: vec![
-                    ValidationRule::DirectoryExists("assets/models".to_string()),
-                    ValidationRule::DirectoryExists("assets/textures".to_string()),
-                    ValidationRule::DirectoryExists("assets/sounds".to_string()),
-                    ValidationRule::DirectoryExists("assets/shaders".to_string()),
-                    ValidationRule::DirectoryExists(".github/workflows".to_string()),
-                    ValidationRule::FileExists("assets/README.md".to_string()),
-                    ValidationRule::FileExists(".github/workflows/wasm.yml".to_string()),
-                    ValidationRule::CargoCheckPasses,
-                ],
-            },
-        ]);
+        matrix.extend(vec![MatrixTestConfig {
+            name: "cross-platform-paths".to_string(),
+            project_type: "game-engine".to_string(),
+            author: "Cross Platform <cross@example.com>".to_string(),
+            description: Some("Testing cross-platform path handling".to_string()),
+            features: vec![],
+            test_category: "Cross-Platform".to_string(),
+            expected_behavior: TestExpectation::Success,
+            validation_rules: vec![
+                ValidationRule::DirectoryExists("assets/models".to_string()),
+                ValidationRule::DirectoryExists("assets/textures".to_string()),
+                ValidationRule::DirectoryExists("assets/sounds".to_string()),
+                ValidationRule::DirectoryExists("assets/shaders".to_string()),
+                ValidationRule::DirectoryExists(".github/workflows".to_string()),
+                ValidationRule::FileExists("assets/README.md".to_string()),
+                ValidationRule::FileExists(".github/workflows/wasm.yml".to_string()),
+                ValidationRule::CargoCheckPasses,
+            ],
+        }]);
 
         // Performance and stress tests
         matrix.extend(vec![
@@ -375,7 +406,11 @@ impl FeatureMatrixTestSuite {
     }
 
     /// Apply a single validation rule
-    fn apply_validation_rule(&self, rule: &ValidationRule, project_dir: &Path) -> Result<(), String> {
+    fn apply_validation_rule(
+        &self,
+        rule: &ValidationRule,
+        project_dir: &Path,
+    ) -> Result<(), String> {
         match rule {
             ValidationRule::FileExists(file) => {
                 let path = project_dir.join(file);
@@ -460,7 +495,10 @@ impl FeatureMatrixTestSuite {
                     .map_err(|e| format!("Failed to get metadata for {}: {}", file, e))?;
                 let size = metadata.len();
                 if size < *min_size || size > *max_size {
-                    return Err(format!("File {} size {} is not in range {}-{}", file, size, min_size, max_size));
+                    return Err(format!(
+                        "File {} size {} is not in range {}-{}",
+                        file, size, min_size, max_size
+                    ));
                 }
             }
             ValidationRule::LineCount(file, min_lines, max_lines) => {
@@ -469,7 +507,10 @@ impl FeatureMatrixTestSuite {
                     .map_err(|e| format!("Failed to read {}: {}", file, e))?;
                 let line_count = content.lines().count();
                 if line_count < *min_lines || line_count > *max_lines {
-                    return Err(format!("File {} line count {} is not in range {}-{}", file, line_count, min_lines, max_lines));
+                    return Err(format!(
+                        "File {} line count {} is not in range {}-{}",
+                        file, line_count, min_lines, max_lines
+                    ));
                 }
             }
         }
@@ -479,7 +520,7 @@ impl FeatureMatrixTestSuite {
     /// Run a single matrix test
     fn run_matrix_test(&mut self, config: &MatrixTestConfig) -> Result<(), String> {
         let project_dir = self.temp_dir.path().join(&config.name);
-        
+
         // Generate project
         let basic_config = ProjectConfig {
             name: config.name.clone(),
@@ -489,7 +530,8 @@ impl FeatureMatrixTestSuite {
             features: config.features.clone(),
         };
 
-        self.generator.generate(&basic_config, &project_dir)
+        self.generator
+            .generate(&basic_config, &project_dir)
             .map_err(|e| format!("Failed to generate project: {}", e))?;
 
         // Apply validation rules
@@ -504,7 +546,7 @@ impl FeatureMatrixTestSuite {
     pub fn run_all_matrix_tests(&mut self) -> HashMap<String, Result<(), String>> {
         let matrix = Self::generate_test_matrix();
         let mut results = HashMap::new();
-        
+
         for config in matrix {
             let result = self.run_matrix_test(&config);
             match &result {
@@ -513,7 +555,7 @@ impl FeatureMatrixTestSuite {
             }
             results.insert(config.name.clone(), result);
         }
-        
+
         results
     }
 
@@ -521,45 +563,54 @@ impl FeatureMatrixTestSuite {
     pub fn generate_matrix_report(&self, results: &HashMap<String, Result<(), String>>) -> String {
         let mut report = String::new();
         report.push_str("=== Feature Matrix Test Report ===\n\n");
-        
+
         // Group results by category
         let matrix = Self::generate_test_matrix();
         let mut categories: HashMap<String, Vec<(String, bool)>> = HashMap::new();
-        
+
         for config in matrix {
             let category = config.test_category.clone();
             let test_name = config.name.clone();
             let success = results.get(&test_name).map_or(false, |r| r.is_ok());
-            
-            categories.entry(category).or_insert_with(Vec::new).push((test_name, success));
+
+            categories
+                .entry(category)
+                .or_insert_with(Vec::new)
+                .push((test_name, success));
         }
-        
+
         // Generate report by category
         for (category, tests) in categories {
             let total = tests.len();
             let passed = tests.iter().filter(|(_, success)| *success).count();
             let failed = total - passed;
-            
+
             report.push_str(&format!("## {}\n", category));
-            report.push_str(&format!("Total: {}, Passed: {}, Failed: {}\n", total, passed, failed));
-            
+            report.push_str(&format!(
+                "Total: {}, Passed: {}, Failed: {}\n",
+                total, passed, failed
+            ));
+
             for (test_name, success) in tests {
                 let status = if success { "PASS" } else { "FAIL" };
                 report.push_str(&format!("  {} - {}\n", test_name, status));
             }
             report.push('\n');
         }
-        
+
         let total_tests = results.len();
         let passed_tests = results.values().filter(|r| r.is_ok()).count();
         let failed_tests = total_tests - passed_tests;
-        
+
         report.push_str(&format!("=== Summary ===\n"));
         report.push_str(&format!("Total Tests: {}\n", total_tests));
         report.push_str(&format!("Passed: {}\n", passed_tests));
         report.push_str(&format!("Failed: {}\n", failed_tests));
-        report.push_str(&format!("Success Rate: {:.2}%\n", (passed_tests as f64 / total_tests as f64) * 100.0));
-        
+        report.push_str(&format!(
+            "Success Rate: {:.2}%\n",
+            (passed_tests as f64 / total_tests as f64) * 100.0
+        ));
+
         report
     }
 }
@@ -569,17 +620,18 @@ impl FeatureMatrixTestSuite {
 fn test_feature_matrix_comprehensive() {
     let mut test_suite = FeatureMatrixTestSuite::new();
     let results = test_suite.run_all_matrix_tests();
-    
+
     // Generate and print report
     let report = test_suite.generate_matrix_report(&results);
     println!("{}", report);
-    
+
     // Ensure all tests passed
-    let failed_tests: Vec<&String> = results.iter()
+    let failed_tests: Vec<&String> = results
+        .iter()
         .filter(|(_, result)| result.is_err())
         .map(|(name, _)| name)
         .collect();
-    
+
     if !failed_tests.is_empty() {
         panic!("The following matrix tests failed: {:?}", failed_tests);
     }
@@ -589,14 +641,14 @@ fn test_feature_matrix_comprehensive() {
 #[test]
 fn test_edge_cases() {
     let mut test_suite = FeatureMatrixTestSuite::new();
-    
+
     // Test single character project name
     let config = MatrixTestConfig {
         name: "x".to_string(),
         project_type: "library".to_string(),
         author: "Test <test@example.com>".to_string(),
         description: Some("Single char test".to_string()),
-                features: vec![],
+        features: vec![],
         test_category: "Edge Cases".to_string(),
         expected_behavior: TestExpectation::Success,
         validation_rules: vec![
@@ -604,8 +656,9 @@ fn test_edge_cases() {
             ValidationRule::FileExists("Cargo.toml".to_string()),
         ],
     };
-    
-    test_suite.run_matrix_test(&config)
+
+    test_suite
+        .run_matrix_test(&config)
         .expect("Single character project name should work");
 }
 
@@ -614,7 +667,7 @@ fn test_edge_cases() {
 fn test_matrix_performance() {
     let start_time = std::time::Instant::now();
     let mut test_suite = FeatureMatrixTestSuite::new();
-    
+
     // Generate multiple projects rapidly
     let configs = vec![
         MatrixTestConfig {
@@ -622,7 +675,7 @@ fn test_matrix_performance() {
             project_type: "library".to_string(),
             author: "Perf Test <perf@example.com>".to_string(),
             description: Some("Performance test 1".to_string()),
-                features: vec![],
+            features: vec![],
             test_category: "Performance".to_string(),
             expected_behavior: TestExpectation::Success,
             validation_rules: vec![ValidationRule::CargoCheckPasses],
@@ -632,7 +685,7 @@ fn test_matrix_performance() {
             project_type: "cli-tool".to_string(),
             author: "Perf Test <perf@example.com>".to_string(),
             description: Some("Performance test 2".to_string()),
-                features: vec![],
+            features: vec![],
             test_category: "Performance".to_string(),
             expected_behavior: TestExpectation::Success,
             validation_rules: vec![ValidationRule::CargoCheckPasses],
@@ -642,21 +695,26 @@ fn test_matrix_performance() {
             project_type: "api-server".to_string(),
             author: "Perf Test <perf@example.com>".to_string(),
             description: Some("Performance test 3".to_string()),
-                features: vec![],
+            features: vec![],
             test_category: "Performance".to_string(),
             expected_behavior: TestExpectation::Success,
             validation_rules: vec![ValidationRule::CargoCheckPasses],
         },
     ];
-    
+
     for config in configs {
-        test_suite.run_matrix_test(&config)
+        test_suite
+            .run_matrix_test(&config)
             .expect(&format!("Performance test {} should pass", config.name));
     }
-    
+
     let elapsed = start_time.elapsed();
     println!("Matrix performance test completed in {:?}", elapsed);
-    
+
     // Should complete within reasonable time
-    assert!(elapsed.as_secs() < 60, "Matrix performance test took too long: {:?}", elapsed);
+    assert!(
+        elapsed.as_secs() < 60,
+        "Matrix performance test took too long: {:?}",
+        elapsed
+    );
 }

--- a/tests/e2e_systematic_validation.rs
+++ b/tests/e2e_systematic_validation.rs
@@ -431,6 +431,8 @@ impl E2ETestSuite {
             author: config.author.clone(),
             description: config.description.clone(),
             features: vec![],
+            target: None,
+            esp32_chip: None,
         };
 
         self.generator

--- a/tests/e2e_systematic_validation.rs
+++ b/tests/e2e_systematic_validation.rs
@@ -1,9 +1,9 @@
 use cargo_forge::{Generator, ProjectConfig};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-use std::collections::HashMap;
 
 /// Comprehensive end-to-end testing framework for project generation validation
 /// This module provides systematic testing of all project types, feature combinations,
@@ -63,7 +63,11 @@ impl TestConfig {
         self
     }
 
-    pub fn with_gitignore_requirements(mut self, must_have: Vec<&str>, must_not_have: Vec<&str>) -> Self {
+    pub fn with_gitignore_requirements(
+        mut self,
+        must_have: Vec<&str>,
+        must_not_have: Vec<&str>,
+    ) -> Self {
         self.gitignore_must_have = must_have.into_iter().map(|s| s.to_string()).collect();
         self.gitignore_must_not_have = must_not_have.into_iter().map(|s| s.to_string()).collect();
         self
@@ -121,7 +125,7 @@ impl E2ETestSuite {
             TestConfig::new("e2e-cli-tool", "cli-tool")
                 .with_expected_files(vec![
                     "src/main.rs",
-                    "src/cli.rs", 
+                    "src/cli.rs",
                     "src/commands.rs",
                     "Cargo.toml",
                     "README.md",
@@ -131,7 +135,6 @@ impl E2ETestSuite {
                 .with_required_cargo_sections(vec!["[package]", "[[bin]]", "[dependencies]"])
                 .with_gitignore_requirements(vec!["/target"], vec!["Cargo.lock"])
                 .with_cargo_support(true, true, true),
-
             // Library configuration
             TestConfig::new("e2e-library", "library")
                 .with_expected_files(vec![
@@ -145,7 +148,6 @@ impl E2ETestSuite {
                 .with_required_cargo_sections(vec!["[package]", "[lib]"])
                 .with_gitignore_requirements(vec!["/target", "Cargo.lock"], vec![])
                 .with_cargo_support(true, true, true),
-
             // API Server configuration
             TestConfig::new("e2e-api-server", "api-server")
                 .with_expected_files(vec![
@@ -163,7 +165,6 @@ impl E2ETestSuite {
                 .with_required_cargo_sections(vec!["[package]", "[dependencies]"])
                 .with_gitignore_requirements(vec!["/target"], vec![])
                 .with_cargo_support(true, true, true),
-
             // WASM App configuration
             TestConfig::new("e2e-wasm-app", "wasm-app")
                 .with_expected_files(vec![
@@ -179,9 +180,11 @@ impl E2ETestSuite {
                 ])
                 .with_expected_dependencies(vec!["wasm-bindgen", "web-sys", "js-sys"])
                 .with_required_cargo_sections(vec!["[package]", "[lib]", "[dependencies]"])
-                .with_gitignore_requirements(vec!["/target", "node_modules", "dist/", "pkg/"], vec![])
+                .with_gitignore_requirements(
+                    vec!["/target", "node_modules", "dist/", "pkg/"],
+                    vec![],
+                )
                 .with_cargo_support(true, false, false), // WASM needs special build setup
-
             // Game Engine configuration
             TestConfig::new("e2e-game-engine", "game-engine")
                 .with_expected_files(vec![
@@ -198,9 +201,11 @@ impl E2ETestSuite {
                 ])
                 .with_expected_dependencies(vec!["bevy"])
                 .with_required_cargo_sections(vec!["[package]", "[dependencies]", "[profile.dev]"])
-                .with_gitignore_requirements(vec!["/target", "wasm/", "*.wasm", ".DS_Store"], vec![])
+                .with_gitignore_requirements(
+                    vec!["/target", "wasm/", "*.wasm", ".DS_Store"],
+                    vec![],
+                )
                 .with_cargo_support(true, true, true),
-
             // Embedded configuration
             TestConfig::new("e2e-embedded", "embedded")
                 .with_expected_files(vec![
@@ -213,10 +218,17 @@ impl E2ETestSuite {
                     ".gitignore",
                 ])
                 .with_expected_dependencies(vec!["cortex-m", "cortex-m-rt", "panic-halt"])
-                .with_required_cargo_sections(vec!["[package]", "[dependencies]", "[profile.dev]", "[profile.release]"])
-                .with_gitignore_requirements(vec!["/target", "*.bin", "*.hex", "*.elf", ".vscode/"], vec![])
+                .with_required_cargo_sections(vec![
+                    "[package]",
+                    "[dependencies]",
+                    "[profile.dev]",
+                    "[profile.release]",
+                ])
+                .with_gitignore_requirements(
+                    vec!["/target", "*.bin", "*.hex", "*.elf", ".vscode/"],
+                    vec![],
+                )
                 .with_cargo_support(false, false, false), // Embedded needs special targets
-
             // Workspace configuration
             TestConfig::new("e2e-workspace", "workspace")
                 .with_expected_files(vec![
@@ -235,14 +247,22 @@ impl E2ETestSuite {
                     ".gitignore",
                 ])
                 .with_expected_dependencies(vec!["tokio", "serde", "anyhow"])
-                .with_required_cargo_sections(vec!["[workspace]", "[workspace.package]", "[workspace.dependencies]"])
+                .with_required_cargo_sections(vec![
+                    "[workspace]",
+                    "[workspace.package]",
+                    "[workspace.dependencies]",
+                ])
                 .with_gitignore_requirements(vec!["/target", "Cargo.lock"], vec![])
                 .with_cargo_support(true, true, true),
         ]
     }
 
     /// Validate project structure according to test configuration
-    fn validate_project_structure(&self, config: &TestConfig, project_dir: &Path) -> Result<(), String> {
+    fn validate_project_structure(
+        &self,
+        config: &TestConfig,
+        project_dir: &Path,
+    ) -> Result<(), String> {
         for file in &config.expected_files {
             let file_path = project_dir.join(file);
             if file.ends_with('/') {
@@ -360,7 +380,11 @@ impl E2ETestSuite {
     }
 
     /// Validate cargo operations
-    fn validate_cargo_operations(&self, config: &TestConfig, project_dir: &Path) -> Result<(), String> {
+    fn validate_cargo_operations(
+        &self,
+        config: &TestConfig,
+        project_dir: &Path,
+    ) -> Result<(), String> {
         if config.supports_cargo_check {
             self.run_cargo_command(project_dir, "check")
                 .map_err(|e| format!("Cargo check failed: {}", e))?;
@@ -380,7 +404,11 @@ impl E2ETestSuite {
     }
 
     /// Validate platform-specific requirements
-    fn validate_platform_requirements(&self, config: &TestConfig, project_dir: &Path) -> Result<(), String> {
+    fn validate_platform_requirements(
+        &self,
+        config: &TestConfig,
+        project_dir: &Path,
+    ) -> Result<(), String> {
         let platform = Self::get_platform();
         if let Some(requirements) = config.platform_specific_requirements.get(&platform) {
             for requirement in requirements {
@@ -395,7 +423,7 @@ impl E2ETestSuite {
     /// Run comprehensive validation for a single project
     fn validate_single_project(&mut self, config: &TestConfig) -> Result<(), String> {
         let project_dir = self.temp_dir.path().join(&config.name);
-        
+
         // Generate project
         let basic_config = ProjectConfig {
             name: config.name.clone(),
@@ -405,7 +433,8 @@ impl E2ETestSuite {
             features: vec![],
         };
 
-        self.generator.generate(&basic_config, &project_dir)
+        self.generator
+            .generate(&basic_config, &project_dir)
             .map_err(|e| format!("Failed to generate project: {}", e))?;
 
         // Validate structure
@@ -432,7 +461,7 @@ impl E2ETestSuite {
     /// Run validation for all project types
     pub fn run_all_validations(&mut self) -> HashMap<String, bool> {
         let configs = Self::get_all_project_test_configs();
-        
+
         for config in configs {
             let result = self.validate_single_project(&config);
             match result {
@@ -446,7 +475,7 @@ impl E2ETestSuite {
                 }
             }
         }
-        
+
         self.test_results.clone()
     }
 
@@ -454,25 +483,31 @@ impl E2ETestSuite {
     pub fn generate_test_report(&self) -> String {
         let mut report = String::new();
         report.push_str("=== E2E Systematic Validation Report ===\n\n");
-        
+
         let total_tests = self.test_results.len();
         let passed_tests = self.test_results.values().filter(|&&result| result).count();
         let failed_tests = total_tests - passed_tests;
-        
+
         report.push_str(&format!("Total Tests: {}\n", total_tests));
         report.push_str(&format!("Passed: {}\n", passed_tests));
         report.push_str(&format!("Failed: {}\n", failed_tests));
-        report.push_str(&format!("Success Rate: {:.2}%\n\n", (passed_tests as f64 / total_tests as f64) * 100.0));
-        
+        report.push_str(&format!(
+            "Success Rate: {:.2}%\n\n",
+            (passed_tests as f64 / total_tests as f64) * 100.0
+        ));
+
         report.push_str("Test Results:\n");
         for (test_name, result) in &self.test_results {
             let status = if *result { "PASS" } else { "FAIL" };
             report.push_str(&format!("  {} - {}\n", test_name, status));
         }
-        
+
         report.push_str(&format!("\nPlatform: {}\n", Self::get_platform()));
-        report.push_str(&format!("Timestamp: {}\n", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")));
-        
+        report.push_str(&format!(
+            "Timestamp: {}\n",
+            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        ));
+
         report
     }
 }
@@ -482,17 +517,18 @@ impl E2ETestSuite {
 fn test_systematic_e2e_validation() {
     let mut test_suite = E2ETestSuite::new();
     let results = test_suite.run_all_validations();
-    
+
     // Generate and print report
     let report = test_suite.generate_test_report();
     println!("{}", report);
-    
+
     // Ensure all tests passed
-    let failed_tests: Vec<&String> = results.iter()
+    let failed_tests: Vec<&String> = results
+        .iter()
         .filter(|(_, &result)| !result)
         .map(|(name, _)| name)
         .collect();
-    
+
     if !failed_tests.is_empty() {
         panic!("The following tests failed: {:?}", failed_tests);
     }
@@ -502,7 +538,7 @@ fn test_systematic_e2e_validation() {
 #[test]
 fn test_individual_project_validations() {
     let configs = E2ETestSuite::get_all_project_test_configs();
-    
+
     for config in configs {
         let mut test_suite = E2ETestSuite::new();
         match test_suite.validate_single_project(&config) {
@@ -517,20 +553,26 @@ fn test_individual_project_validations() {
 fn test_cross_platform_compatibility() {
     let mut test_suite = E2ETestSuite::new();
     let platform = E2ETestSuite::get_platform();
-    
+
     println!("Running cross-platform compatibility test on: {}", platform);
-    
+
     // Test a subset of project types for cross-platform compatibility
     let cross_platform_configs = vec![
         TestConfig::new("cross-platform-cli", "cli-tool"),
         TestConfig::new("cross-platform-lib", "library"),
         TestConfig::new("cross-platform-api", "api-server"),
     ];
-    
+
     for config in cross_platform_configs {
         match test_suite.validate_single_project(&config) {
-            Ok(()) => println!("✅ Cross-platform test for {} passed on {}", config.name, platform),
-            Err(e) => panic!("❌ Cross-platform test for {} failed on {}: {}", config.name, platform, e),
+            Ok(()) => println!(
+                "✅ Cross-platform test for {} passed on {}",
+                config.name, platform
+            ),
+            Err(e) => panic!(
+                "❌ Cross-platform test for {} failed on {}: {}",
+                config.name, platform, e
+            ),
         }
     }
 }
@@ -540,22 +582,27 @@ fn test_cross_platform_compatibility() {
 fn test_project_generation_performance() {
     let start_time = std::time::Instant::now();
     let mut test_suite = E2ETestSuite::new();
-    
+
     // Generate multiple projects quickly
     let performance_configs = vec![
         TestConfig::new("perf-test-1", "library"),
         TestConfig::new("perf-test-2", "cli-tool"),
         TestConfig::new("perf-test-3", "api-server"),
     ];
-    
+
     for config in performance_configs {
-        test_suite.validate_single_project(&config)
+        test_suite
+            .validate_single_project(&config)
             .expect(&format!("Performance test failed for {}", config.name));
     }
-    
+
     let elapsed = start_time.elapsed();
     println!("Performance test completed in {:?}", elapsed);
-    
+
     // Ensure reasonable performance (should complete in under 3 minutes for 3 projects)
-    assert!(elapsed.as_secs() < 180, "Project generation performance test took too long: {:?}", elapsed);
+    assert!(
+        elapsed.as_secs() < 180,
+        "Project generation performance test took too long: {:?}",
+        elapsed
+    );
 }

--- a/tests/error_cases_test.rs
+++ b/tests/error_cases_test.rs
@@ -25,6 +25,8 @@ mod generator_error_tests {
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
             features: vec![],
+            target: None,
+            esp32_chip: None
         };
 
         let output_dir = temp_dir.path().join("empty-name-test");

--- a/tests/error_cases_test.rs
+++ b/tests/error_cases_test.rs
@@ -57,6 +57,8 @@ mod generator_error_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -88,6 +90,8 @@ mod generator_error_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -113,6 +117,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -135,6 +141,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -163,6 +171,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -186,6 +196,8 @@ mod generator_error_tests {
             project_type: "invalid-type".to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -210,6 +222,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -240,6 +254,8 @@ mod generator_error_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -267,6 +283,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: None,
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -289,6 +307,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -313,6 +333,8 @@ mod generator_error_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -398,6 +420,8 @@ mod extreme_edge_cases {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -426,6 +450,8 @@ mod extreme_edge_cases {
             project_type: ProjectType::Library.to_string(),
             author: long_author,
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -453,6 +479,8 @@ mod extreme_edge_cases {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some(long_description.clone()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -486,6 +514,8 @@ mod extreme_edge_cases {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -514,6 +544,8 @@ mod extreme_edge_cases {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -541,6 +573,8 @@ mod extreme_edge_cases {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -574,6 +608,8 @@ mod extreme_edge_cases {
                 project_type: project_type.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -624,6 +660,8 @@ mod concurrency_tests {
                         project_type: ProjectType::Library.to_string(),
                         author: "Test Author".to_string(),
                         description: Some("Test".to_string()),
+                        esp32_chip: None,
+                        target: None,
                         features: vec![],
                     };
 
@@ -658,6 +696,8 @@ mod concurrency_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some(format!("Rapid test project {}", i)),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -814,6 +854,8 @@ mod recovery_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -844,6 +886,8 @@ mod recovery_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test project for disk full scenario".to_string()),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -875,6 +919,8 @@ mod recovery_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -906,6 +952,8 @@ mod performance_tests {
             project_type: ProjectType::Workspace.to_string(),
             author: "Test Author".to_string(),
             description: Some("Large workspace with many crates".to_string()),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -951,6 +999,8 @@ mod performance_tests {
                 project_type,
                 author: "Test Author".to_string(),
                 description: Some(format!("Performance test for {}", name)),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 
@@ -1009,6 +1059,8 @@ mod performance_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: large_author,
                 description: Some(large_description),
+                esp32_chip: None,
+                target: None,
                 features: vec![],
             };
 

--- a/tests/error_cases_test.rs
+++ b/tests/error_cases_test.rs
@@ -2,8 +2,8 @@ use cargo_forge::{Config, Generator, ProjectConfig, ProjectType};
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -17,16 +17,16 @@ mod generator_error_tests {
     fn test_invalid_project_names() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test empty project name
         let config = ProjectConfig {
             name: "".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("empty-name-test");
         let result = generator.generate(&config, &output_dir);
         // Empty name should work but create minimal content
@@ -37,28 +37,31 @@ mod generator_error_tests {
     fn test_invalid_characters_in_project_name() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test project names with invalid characters
         let invalid_names = vec![
             "project@name",  // @ symbol
-            "project#name",  // # symbol  
+            "project#name",  // # symbol
             "project$name",  // $ symbol
             "project name",  // space
             "project/name",  // slash
             "project\\name", // backslash
             "project:name",  // colon
         ];
-        
+
         for invalid_name in invalid_names {
             let config = ProjectConfig {
                 name: invalid_name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
-            let output_dir = temp_dir.path().join(format!("invalid-name-{}", invalid_name.replace(|c: char| !c.is_alphanumeric(), "-")));
+
+            let output_dir = temp_dir.path().join(format!(
+                "invalid-name-{}",
+                invalid_name.replace(|c: char| !c.is_alphanumeric(), "-")
+            ));
             let result = generator.generate(&config, &output_dir);
             // May succeed or fail depending on implementation - just test the code path
             let _ = result;
@@ -69,24 +72,23 @@ mod generator_error_tests {
     fn test_reserved_project_names() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test reserved Rust keywords as project names
         let reserved_names = vec![
-            "const", "let", "fn", "struct", "enum", "impl", 
-            "trait", "mod", "use", "pub", "match", "if",
-            "else", "while", "for", "loop", "break", "continue",
-            "return", "self", "Self", "super", "crate"
+            "const", "let", "fn", "struct", "enum", "impl", "trait", "mod", "use", "pub", "match",
+            "if", "else", "while", "for", "loop", "break", "continue", "return", "self", "Self",
+            "super", "crate",
         ];
-        
+
         for reserved_name in reserved_names {
             let config = ProjectConfig {
                 name: reserved_name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(format!("reserved-{}", reserved_name));
             let result = generator.generate(&config, &output_dir);
             // May succeed or fail depending on implementation - just test the code path
@@ -99,41 +101,41 @@ mod generator_error_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let output_dir = temp_dir.path().join("existing-dir");
-        
+
         // Create directory with a file
         fs::create_dir_all(&output_dir).unwrap();
         fs::write(output_dir.join("existing-file.txt"), "content").unwrap();
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
     }
 
-    #[test] 
+    #[test]
     fn test_directory_already_exists_empty() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let output_dir = temp_dir.path().join("empty-existing-dir");
-        
+
         // Create empty directory
         fs::create_dir_all(&output_dir).unwrap();
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         // Empty directory should be fine
         assert!(result.is_ok());
@@ -145,26 +147,26 @@ mod generator_error_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let readonly_dir = temp_dir.path().join("readonly");
-        
+
         // Create directory and make it read-only
         fs::create_dir_all(&readonly_dir).unwrap();
         let mut perms = fs::metadata(&readonly_dir).unwrap().permissions();
         perms.set_mode(0o444); // read-only
         fs::set_permissions(&readonly_dir, perms).unwrap();
-        
+
         let output_dir = readonly_dir.join("new-project");
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_err());
-        
+
         // Restore permissions for cleanup
         let mut perms = fs::metadata(&readonly_dir).unwrap().permissions();
         perms.set_mode(0o755);
@@ -176,39 +178,42 @@ mod generator_error_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let output_dir = temp_dir.path().join("invalid-type-test");
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: "invalid-type".to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unknown project type"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown project type"));
     }
 
     #[test]
     fn test_very_long_project_name() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create a very long project name (255+ characters)
         let long_name = "a".repeat(300);
-        
+
         let config = ProjectConfig {
             name: long_name.clone(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("long-name-test");
         let result = generator.generate(&config, &output_dir);
-        
+
         // May fail due to filesystem limitations
         // Don't assert either way since it depends on the filesystem
         let _ = result;
@@ -218,25 +223,31 @@ mod generator_error_tests {
     fn test_unicode_project_name() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         let unicode_names = vec![
             "测试项目",         // Chinese
-            "тестовый-проект",  // Russian 
+            "тестовый-проект",  // Russian
             "プロジェクト",     // Japanese
             "proyecto-español", // Spanish with accents
-            "🚀-rocket",       // Emoji
+            "🚀-rocket",        // Emoji
         ];
-        
+
         for unicode_name in unicode_names {
             let config = ProjectConfig {
                 name: unicode_name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
-            let output_dir = temp_dir.path().join(format!("unicode-{}", unicode_name.chars().filter(|c| c.is_alphanumeric()).collect::<String>()));
+
+            let output_dir = temp_dir.path().join(format!(
+                "unicode-{}",
+                unicode_name
+                    .chars()
+                    .filter(|c| c.is_alphanumeric())
+                    .collect::<String>()
+            ));
             let result = generator.generate(&config, &output_dir);
             // Should succeed for most unicode names
             assert!(result.is_ok(), "Failed for unicode name: {}", unicode_name);
@@ -248,18 +259,18 @@ mod generator_error_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let output_dir = temp_dir.path().join("null-desc-test");
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: None,
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_ok());
-        
+
         // Check that README is generated without description
         let readme_content = fs::read_to_string(output_dir.join("README.md")).unwrap();
         assert!(readme_content.contains("test-project"));
@@ -270,18 +281,18 @@ mod generator_error_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let output_dir = temp_dir.path().join("empty-author-test");
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_ok());
-        
+
         // Check that Cargo.toml is generated with empty author
         let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
         assert!(cargo_content.contains("authors = [\"\"]"));
@@ -291,18 +302,18 @@ mod generator_error_tests {
     fn test_malformed_path_characters() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test paths with potentially problematic characters
         let output_dir = temp_dir.path().join("test..project");
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_ok());
     }
@@ -316,21 +327,25 @@ mod project_type_error_tests {
     #[test]
     fn test_project_type_from_invalid_string() {
         use std::str::FromStr;
-        
+
         let invalid_types = vec![
             "",
             "invalid",
-            "LIBRARY",  // wrong case
-            "lib",      // abbreviation
-            "api",      // abbreviation
-            "wasm",     // abbreviation
-            "web-app",  // wrong format
+            "LIBRARY",         // wrong case
+            "lib",             // abbreviation
+            "api",             // abbreviation
+            "wasm",            // abbreviation
+            "web-app",         // wrong format
             "library-project", // too specific
         ];
-        
+
         for invalid_type in invalid_types {
             let result = ProjectType::from_str(invalid_type);
-            assert!(result.is_err(), "Should fail for invalid type: {}", invalid_type);
+            assert!(
+                result.is_err(),
+                "Should fail for invalid type: {}",
+                invalid_type
+            );
         }
     }
 
@@ -346,7 +361,7 @@ mod project_type_error_tests {
             ProjectType::Embedded,
             ProjectType::Workspace,
         ];
-        
+
         for project_type in types {
             let type_string = project_type.to_string();
             let parsed_type = ProjectType::from_str(&type_string).unwrap();
@@ -364,27 +379,32 @@ mod extreme_edge_cases {
     fn test_control_characters_in_project_name() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test various control characters
         let control_char_names = vec![
-            "project\nname",     // newline
-            "project\tname",     // tab
-            "project\rname",     // carriage return
-            "project\0name",     // null byte
-            "project\x1bname",   // escape character
-            "project\x7fname",   // delete character
+            "project\nname",   // newline
+            "project\tname",   // tab
+            "project\rname",   // carriage return
+            "project\0name",   // null byte
+            "project\x1bname", // escape character
+            "project\x7fname", // delete character
         ];
-        
+
         for name in control_char_names {
             let config = ProjectConfig {
                 name: name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
-            let output_dir = temp_dir.path().join(format!("control-{}", name.chars().filter(|c| c.is_alphanumeric()).collect::<String>()));
+
+            let output_dir = temp_dir.path().join(format!(
+                "control-{}",
+                name.chars()
+                    .filter(|c| c.is_alphanumeric())
+                    .collect::<String>()
+            ));
             let result = generator.generate(&config, &output_dir);
             // Should handle control characters gracefully
             let _ = result;
@@ -395,24 +415,24 @@ mod extreme_edge_cases {
     fn test_extremely_long_author_name() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create an extremely long author name (10KB)
         let long_author = "A".repeat(10_000);
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: long_author,
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("long-author-test");
         let result = generator.generate(&config, &output_dir);
-        
+
         // Should succeed even with very long author name
         assert!(result.is_ok());
-        
+
         // Verify the Cargo.toml was created
         let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
         assert!(cargo_content.len() > 10_000); // Should contain the long author name
@@ -422,24 +442,24 @@ mod extreme_edge_cases {
     fn test_extremely_long_description() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create an extremely long description (100KB)
         let long_description = "This is a very long description. ".repeat(3000);
-        
+
         let config = ProjectConfig {
             name: "test-project".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some(long_description.clone()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("long-desc-test");
         let result = generator.generate(&config, &output_dir);
-        
+
         // Should succeed
         assert!(result.is_ok());
-        
+
         // Verify the README contains the long description
         let readme_content = fs::read_to_string(output_dir.join("README.md")).unwrap();
         assert!(readme_content.contains(&long_description[..50])); // Check first 50 chars
@@ -449,7 +469,7 @@ mod extreme_edge_cases {
     fn test_path_traversal_attempts() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test path traversal attempts in project name
         let traversal_names = vec![
             "../../../etc/passwd",
@@ -457,22 +477,22 @@ mod extreme_edge_cases {
             "./../../sensitive",
             "~/.ssh/id_rsa",
         ];
-        
+
         for name in traversal_names {
             let config = ProjectConfig {
                 name: name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join("traversal-test");
             let result = generator.generate(&config, &output_dir);
-            
+
             // Should handle these safely
             let _ = result;
-            
+
             // Clean up for next iteration
             let _ = fs::remove_dir_all(&output_dir);
         }
@@ -482,19 +502,19 @@ mod extreme_edge_cases {
     fn test_filesystem_limits() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test with maximum path length (varies by OS, typically 255-260 chars)
         let very_long_path = "a".repeat(200);
         let output_dir = temp_dir.path().join(&very_long_path);
-        
+
         let config = ProjectConfig {
             name: "test".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
         // May fail due to filesystem limits
         let _ = result;
@@ -504,24 +524,24 @@ mod extreme_edge_cases {
     fn test_special_filesystem_names() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test reserved names on various operating systems
         let special_names = vec![
-            "CON", "PRN", "AUX", "NUL",          // Windows reserved
-            "COM1", "COM2", "LPT1", "LPT2",      // Windows devices
-            ".", "..",                          // Unix special
-            ".git", ".cargo",                   // Hidden/special dirs
+            "CON", "PRN", "AUX", "NUL", // Windows reserved
+            "COM1", "COM2", "LPT1", "LPT2", // Windows devices
+            ".", "..", // Unix special
+            ".git", ".cargo", // Hidden/special dirs
         ];
-        
+
         for name in special_names {
             let config = ProjectConfig {
                 name: name.to_string(),
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(format!("special-{}", name));
             let result = generator.generate(&config, &output_dir);
             let _ = result;
@@ -532,7 +552,7 @@ mod extreme_edge_cases {
     fn test_mixed_case_project_types() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Test various case variations that should fail
         let mixed_cases = vec![
             ("Library", "library1"),
@@ -545,24 +565,33 @@ mod extreme_edge_cases {
             ("CLI-TOOL", "cli2"),
             ("cli-TOOL", "cli3"),
         ];
-        
+
         for (project_type, unique_name) in mixed_cases {
             let config = ProjectConfig {
                 name: "test-project".to_string(),
                 project_type: project_type.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(unique_name);
             let result = generator.generate(&config, &output_dir);
-            
+
             // Should fail due to invalid project type
-            assert!(result.is_err(), "Expected error for mixed case project type '{}', but generation succeeded", project_type);
+            assert!(
+                result.is_err(),
+                "Expected error for mixed case project type '{}', but generation succeeded",
+                project_type
+            );
             let error_msg = result.unwrap_err().to_string();
-            assert!(error_msg.contains("Unknown project type") || error_msg.contains("unknown project type"),
-                "Expected 'Unknown project type' error for '{}', but got: {}", project_type, error_msg);
+            assert!(
+                error_msg.contains("Unknown project type")
+                    || error_msg.contains("unknown project type"),
+                "Expected 'Unknown project type' error for '{}', but got: {}",
+                project_type,
+                error_msg
+            );
         }
     }
 }
@@ -578,14 +607,14 @@ mod concurrency_tests {
         let output_dir = Arc::new(temp_dir.path().join("concurrent-test"));
         let success_count = Arc::new(AtomicUsize::new(0));
         let failure_count = Arc::new(AtomicUsize::new(0));
-        
+
         // Spawn multiple threads trying to generate to the same directory
         let handles: Vec<_> = (0..10)
             .map(|i| {
                 let output_dir = Arc::clone(&output_dir);
                 let success_count = Arc::clone(&success_count);
                 let failure_count = Arc::clone(&failure_count);
-                
+
                 thread::spawn(move || {
                     let generator = Generator::new();
                     let config = ProjectConfig {
@@ -593,9 +622,9 @@ mod concurrency_tests {
                         project_type: ProjectType::Library.to_string(),
                         author: "Test Author".to_string(),
                         description: Some("Test".to_string()),
-        features: vec![],
+                        features: vec![],
                     };
-                    
+
                     match generator.generate(&config, &output_dir) {
                         Ok(_) => success_count.fetch_add(1, Ordering::SeqCst),
                         Err(_) => failure_count.fetch_add(1, Ordering::SeqCst),
@@ -603,12 +632,12 @@ mod concurrency_tests {
                 })
             })
             .collect();
-        
+
         // Wait for all threads to complete
         for handle in handles {
             handle.join().unwrap();
         }
-        
+
         // Only one should succeed, others should fail
         assert_eq!(success_count.load(Ordering::SeqCst), 1);
         assert_eq!(failure_count.load(Ordering::SeqCst), 9);
@@ -618,7 +647,7 @@ mod concurrency_tests {
     fn test_rapid_sequential_generation() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Generate many projects rapidly
         let start = Instant::now();
         for i in 0..50 {
@@ -629,15 +658,15 @@ mod concurrency_tests {
                 description: Some(format!("Rapid test project {}", i)),
                 features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(format!("rapid-{}", i));
             let result = generator.generate(&config, &output_dir);
             assert!(result.is_ok(), "Failed on iteration {}: {:?}", i, result);
         }
-        
+
         let duration = start.elapsed();
         println!("Generated 50 projects in {:?}", duration);
-        
+
         // Should complete reasonably quickly (within 10 seconds)
         assert!(duration < Duration::from_secs(10));
     }
@@ -652,7 +681,7 @@ mod config_edge_cases {
     fn test_malformed_config_file() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("malformed.toml");
-        
+
         // Write various malformed TOML content
         let malformed_configs = vec![
             "this is not valid toml",
@@ -661,7 +690,7 @@ mod config_edge_cases {
             "key = value = invalid",
             "[section]\nkey = \"unclosed string",
         ];
-        
+
         for content in malformed_configs {
             fs::write(&config_path, content).unwrap();
             let result = Config::load_from_file(&config_path);
@@ -673,14 +702,14 @@ mod config_edge_cases {
     fn test_config_with_invalid_values() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("invalid_values.toml");
-        
+
         // Test config with wrong types
         let invalid_configs = vec![
-            "remember_choices = \"yes\"",  // Should be bool
-            "custom_template_dirs = \"not an array\"",  // Should be array
-            "default_author = 123",  // Should be string
+            "remember_choices = \"yes\"",              // Should be bool
+            "custom_template_dirs = \"not an array\"", // Should be array
+            "default_author = 123",                    // Should be string
         ];
-        
+
         for content in invalid_configs {
             fs::write(&config_path, content).unwrap();
             let result = Config::load_from_file(&config_path);
@@ -692,17 +721,17 @@ mod config_edge_cases {
     fn test_config_with_huge_arrays() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("huge_array.toml");
-        
+
         // Create config with thousands of template directories
         let mut content = "custom_template_dirs = [\n".to_string();
         for i in 0..10000 {
             content.push_str(&format!("  \"/path/to/template/{}\",\n", i));
         }
         content.push_str("]\n");
-        
+
         fs::write(&config_path, content).unwrap();
         let result = Config::load_from_file(&config_path);
-        
+
         // Should handle large arrays
         assert!(result.is_ok());
         let config = result.unwrap();
@@ -713,23 +742,23 @@ mod config_edge_cases {
     fn test_config_permission_denied() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("readonly.toml");
-        
+
         // Create a config file
         let config = Config::new();
         config.save_to_file(&config_path).unwrap();
-        
+
         // Make it read-only
         let mut perms = fs::metadata(&config_path).unwrap().permissions();
         perms.set_mode(0o444);
         fs::set_permissions(&config_path, perms.clone()).unwrap();
-        
+
         // Try to save to it again
         let mut new_config = Config::new();
         new_config.default_author = Some("New Author".to_string());
         let result = new_config.save_to_file(&config_path);
-        
+
         assert!(result.is_err());
-        
+
         // Restore permissions for cleanup
         perms.set_mode(0o644);
         fs::set_permissions(&config_path, perms).unwrap();
@@ -738,24 +767,24 @@ mod config_edge_cases {
     #[test]
     fn test_config_circular_references() {
         let temp_dir = TempDir::new().unwrap();
-        
+
         // Create a directory structure with circular symlinks
         let dir1 = temp_dir.path().join("dir1");
         let dir2 = temp_dir.path().join("dir2");
         fs::create_dir(&dir1).unwrap();
         fs::create_dir(&dir2).unwrap();
-        
+
         #[cfg(unix)]
         {
             use std::os::unix::fs::symlink;
             symlink(&dir2, dir1.join("link_to_dir2")).unwrap();
             symlink(&dir1, dir2.join("link_to_dir1")).unwrap();
         }
-        
+
         let mut config = Config::new();
         config.add_custom_template_directory(dir1.clone());
         config.add_custom_template_directory(dir2.clone());
-        
+
         // Should handle circular references without infinite loops
         assert_eq!(config.custom_template_dirs.len(), 2);
     }
@@ -770,12 +799,12 @@ mod recovery_tests {
     fn test_partial_generation_cleanup() {
         let temp_dir = TempDir::new().unwrap();
         let output_dir = temp_dir.path().join("partial-test");
-        
+
         // Create a partial project structure
         fs::create_dir_all(&output_dir).unwrap();
         fs::create_dir_all(output_dir.join("src")).unwrap();
         fs::write(output_dir.join("Cargo.toml"), "[package]\n").unwrap();
-        
+
         // Now try to generate a project in the same directory
         let generator = Generator::new();
         let config = ProjectConfig {
@@ -783,15 +812,15 @@ mod recovery_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
-        
+
         // Should fail because directory is not empty
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
-        
+
         // Original files should still exist
         assert!(output_dir.join("Cargo.toml").exists());
     }
@@ -801,11 +830,11 @@ mod recovery_tests {
         // This test simulates disk full by creating files until write fails
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create a small file to test write capability
         let test_file = temp_dir.path().join("test_write");
         let write_result = fs::write(&test_file, "test");
-        
+
         if write_result.is_ok() {
             // If we can write, proceed with the test
             let config = ProjectConfig {
@@ -813,12 +842,12 @@ mod recovery_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test project for disk full scenario".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join("disk-full-project");
             let result = generator.generate(&config, &output_dir);
-            
+
             // In normal conditions this should succeed
             assert!(result.is_ok() || result.is_err());
         }
@@ -828,15 +857,15 @@ mod recovery_tests {
     fn test_interrupted_generation_recovery() {
         let temp_dir = TempDir::new().unwrap();
         let output_dir = temp_dir.path().join("interrupted-test");
-        
+
         // Simulate an interrupted generation by creating incomplete structure
         fs::create_dir_all(&output_dir).unwrap();
         fs::create_dir_all(output_dir.join("src")).unwrap();
         // Missing Cargo.toml, README, etc.
-        
+
         // Clean up the incomplete directory
         fs::remove_dir_all(&output_dir).unwrap();
-        
+
         // Try generation again
         let generator = Generator::new();
         let config = ProjectConfig {
@@ -844,14 +873,14 @@ mod recovery_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let result = generator.generate(&config, &output_dir);
-        
+
         // Should succeed after cleanup
         assert!(result.is_ok());
-        
+
         // Verify complete structure
         assert!(output_dir.join("Cargo.toml").exists());
         assert!(output_dir.join("README.md").exists());
@@ -869,26 +898,26 @@ mod performance_tests {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
         let start = Instant::now();
-        
+
         let config = ProjectConfig {
             name: "large-workspace".to_string(),
             project_type: ProjectType::Workspace.to_string(),
             author: "Test Author".to_string(),
             description: Some("Large workspace with many crates".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("large-workspace");
         let result = generator.generate(&config, &output_dir);
-        
+
         assert!(result.is_ok());
-        
+
         let duration = start.elapsed();
         println!("Large workspace generation took: {:?}", duration);
-        
+
         // Should complete within reasonable time (1 second)
         assert!(duration < Duration::from_secs(1));
-        
+
         // Verify all workspace components were created
         assert!(output_dir.join("Cargo.toml").exists());
         assert!(output_dir.join("crates/core/Cargo.toml").exists());
@@ -900,7 +929,7 @@ mod performance_tests {
     fn test_many_files_generation() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Generate each project type and count files
         let project_types = vec![
             (ProjectType::Library.to_string(), "library"),
@@ -911,10 +940,10 @@ mod performance_tests {
             (ProjectType::Embedded.to_string(), "embedded"),
             (ProjectType::Workspace.to_string(), "workspace"),
         ];
-        
+
         for (project_type, name) in project_types {
             let start = Instant::now();
-            
+
             let config = ProjectConfig {
                 name: name.to_string(),
                 project_type,
@@ -922,24 +951,28 @@ mod performance_tests {
                 description: Some(format!("Performance test for {}", name)),
                 features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(name);
             let result = generator.generate(&config, &output_dir);
-            
+
             assert!(result.is_ok(), "Failed to generate {}: {:?}", name, result);
-            
+
             let duration = start.elapsed();
-            
+
             // Count generated files
             let file_count = count_files_recursive(&output_dir);
-            
+
             println!("{}: {} files in {:?}", name, file_count, duration);
-            
+
             // Each project type should generate reasonable number of files
             assert!(file_count >= 3, "{} generated too few files", name);
-            
+
             // Should be fast (under 100ms per project)
-            assert!(duration < Duration::from_millis(100), "{} took too long", name);
+            assert!(
+                duration < Duration::from_millis(100),
+                "{} took too long",
+                name
+            );
         }
     }
 
@@ -963,23 +996,23 @@ mod performance_tests {
     fn test_memory_usage_with_large_configs() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create configs with increasingly large data
         for size_multiplier in [1, 10, 100] {
             let large_description = "x".repeat(1000 * size_multiplier);
             let large_author = "Author ".repeat(100 * size_multiplier);
-            
+
             let config = ProjectConfig {
                 name: format!("memory-test-{}", size_multiplier),
                 project_type: ProjectType::Library.to_string(),
                 author: large_author,
                 description: Some(large_description),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join(format!("memory-{}", size_multiplier));
             let result = generator.generate(&config, &output_dir);
-            
+
             // Should handle large configs without issues
             assert!(result.is_ok());
         }

--- a/tests/feature_combinations_test.rs
+++ b/tests/feature_combinations_test.rs
@@ -18,34 +18,38 @@ impl ProjectWithFeatures {
             dependencies: HashMap::new(),
         }
     }
-    
+
     fn has_feature(&self, feature: &str) -> bool {
         self.features.contains(feature)
     }
-    
+
     fn generate_project_structure(&mut self) -> Vec<PathBuf> {
         let mut files = vec![];
-        
+
         // Base files (always generated)
         files.push(PathBuf::from("Cargo.toml"));
         files.push(PathBuf::from("src/main.rs"));
         files.push(PathBuf::from("src/lib.rs"));
         files.push(PathBuf::from("README.md"));
         files.push(PathBuf::from(".gitignore"));
-        
+
         // API feature files
         if self.has_feature("api") {
             files.push(PathBuf::from("src/routes/mod.rs"));
             files.push(PathBuf::from("src/handlers/mod.rs"));
             files.push(PathBuf::from("src/middleware/mod.rs"));
             files.push(PathBuf::from("src/config.rs"));
-            
-            self.dependencies.insert("axum".to_string(), "0.7".to_string());
-            self.dependencies.insert("tower".to_string(), "0.4".to_string());
-            self.dependencies.insert("tower-http".to_string(), "0.5".to_string());
-            self.dependencies.insert("tokio".to_string(), "1".to_string());
+
+            self.dependencies
+                .insert("axum".to_string(), "0.7".to_string());
+            self.dependencies
+                .insert("tower".to_string(), "0.4".to_string());
+            self.dependencies
+                .insert("tower-http".to_string(), "0.5".to_string());
+            self.dependencies
+                .insert("tokio".to_string(), "1".to_string());
         }
-        
+
         // Database feature files
         if self.has_feature("database") {
             files.push(PathBuf::from("src/db.rs"));
@@ -55,12 +59,15 @@ impl ProjectWithFeatures {
             files.push(PathBuf::from("migrations/002_sessions.sql"));
             files.push(PathBuf::from("src/bin/migrate.rs"));
             files.push(PathBuf::from(".env.database.example"));
-            
-            self.dependencies.insert("sqlx".to_string(), "0.7".to_string());
-            self.dependencies.insert("chrono".to_string(), "0.4".to_string());
-            self.dependencies.insert("uuid".to_string(), "1".to_string());
+
+            self.dependencies
+                .insert("sqlx".to_string(), "0.7".to_string());
+            self.dependencies
+                .insert("chrono".to_string(), "0.4".to_string());
+            self.dependencies
+                .insert("uuid".to_string(), "1".to_string());
         }
-        
+
         // Auth feature files
         if self.has_feature("auth") {
             files.push(PathBuf::from("src/auth/mod.rs"));
@@ -69,81 +76,89 @@ impl ProjectWithFeatures {
             files.push(PathBuf::from("src/auth/middleware.rs"));
             files.push(PathBuf::from("src/auth/routes.rs"));
             files.push(PathBuf::from(".env.auth.example"));
-            
-            self.dependencies.insert("jsonwebtoken".to_string(), "9".to_string());
-            self.dependencies.insert("argon2".to_string(), "0.5".to_string());
-            self.dependencies.insert("validator".to_string(), "0.16".to_string());
-            
+
+            self.dependencies
+                .insert("jsonwebtoken".to_string(), "9".to_string());
+            self.dependencies
+                .insert("argon2".to_string(), "0.5".to_string());
+            self.dependencies
+                .insert("validator".to_string(), "0.16".to_string());
+
             if self.has_feature("oauth") {
                 files.push(PathBuf::from("src/auth/oauth.rs"));
-                self.dependencies.insert("oauth2".to_string(), "4".to_string());
-                self.dependencies.insert("reqwest".to_string(), "0.11".to_string());
+                self.dependencies
+                    .insert("oauth2".to_string(), "4".to_string());
+                self.dependencies
+                    .insert("reqwest".to_string(), "0.11".to_string());
             }
         }
-        
+
         // Docker feature files
         if self.has_feature("docker") {
             files.push(PathBuf::from("Dockerfile"));
             files.push(PathBuf::from(".dockerignore"));
             files.push(PathBuf::from("docker-compose.yml"));
-            
+
             if self.has_feature("database") {
                 files.push(PathBuf::from("docker-compose.dev.yml"));
             }
         }
-        
+
         // CI feature files
         if self.has_feature("ci") {
             files.push(PathBuf::from(".github/workflows/ci.yml"));
             files.push(PathBuf::from(".github/workflows/release.yml"));
-            
+
             if self.has_feature("docker") {
                 files.push(PathBuf::from(".github/workflows/docker.yml"));
             }
         }
-        
+
         files
     }
-    
+
     fn validate_dependencies(&self) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
-        
+
         // Check for dependency conflicts
         if self.has_feature("api") && !self.dependencies.contains_key("tokio") {
             errors.push("API feature requires tokio dependency".to_string());
         }
-        
+
         if self.has_feature("database") && self.has_feature("auth") {
             // These features work well together
             if !self.dependencies.contains_key("sqlx") {
                 errors.push("Database feature should add sqlx dependency".to_string());
             }
         }
-        
+
         if errors.is_empty() {
             Ok(())
         } else {
             Err(errors)
         }
     }
-    
+
     fn generate_docker_compose(&self) -> String {
         let mut compose = String::from("version: '3.8'\n\nservices:\n");
-        
+
         // Main application service
         compose.push_str(&format!(
             "  {}:\n    build: .\n    ports:\n      - \"3000:3000\"\n",
             self.name
         ));
-        
+
         if self.has_feature("database") {
             compose.push_str("    depends_on:\n      - postgres\n");
             compose.push_str("    environment:\n");
-            compose.push_str(&format!("      DATABASE_URL: postgresql://postgres:password@postgres/{}\n", self.name));
+            compose.push_str(&format!(
+                "      DATABASE_URL: postgresql://postgres:password@postgres/{}\n",
+                self.name
+            ));
         }
-        
+
         compose.push_str("\n");
-        
+
         // Database service
         if self.has_feature("database") {
             compose.push_str("  postgres:\n");
@@ -155,7 +170,7 @@ impl ProjectWithFeatures {
             compose.push_str("      - postgres_data:/var/lib/postgresql/data\n");
             compose.push_str("\n");
         }
-        
+
         // Redis service for auth sessions
         if self.has_feature("auth") && self.has_feature("database") {
             compose.push_str("  redis:\n");
@@ -164,13 +179,13 @@ impl ProjectWithFeatures {
             compose.push_str("      - \"6379:6379\"\n");
             compose.push_str("\n");
         }
-        
+
         // Volumes
         if self.has_feature("database") {
             compose.push_str("volumes:\n");
             compose.push_str("  postgres_data:\n");
         }
-        
+
         compose
     }
 }
@@ -178,184 +193,216 @@ impl ProjectWithFeatures {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_api_only_project() {
         let mut project = ProjectWithFeatures::new("api-service", vec!["api"]);
         let files = project.generate_project_structure();
-        
+
         // Should have API-specific files
         assert!(files.iter().any(|f| f.to_str().unwrap().contains("routes")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("handlers")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("middleware")));
-        
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("handlers")));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("middleware")));
+
         // Should have API dependencies
         assert!(project.dependencies.contains_key("axum"));
         assert!(project.dependencies.contains_key("tower"));
-        
+
         // Should not have database files
-        assert!(!files.iter().any(|f| f.to_str().unwrap().contains("migrations")));
+        assert!(!files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("migrations")));
     }
-    
+
     #[test]
     fn test_api_plus_database_combination() {
         let mut project = ProjectWithFeatures::new("full-api", vec!["api", "database"]);
         let files = project.generate_project_structure();
-        
+
         // Should have both API and database files
         assert!(files.iter().any(|f| f.to_str().unwrap().contains("routes")));
         assert!(files.iter().any(|f| f.to_str().unwrap().contains("db.rs")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("migrations")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("migrate.rs")));
-        
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("migrations")));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("migrate.rs")));
+
         // Should have combined dependencies
         assert!(project.dependencies.contains_key("axum"));
         assert!(project.dependencies.contains_key("sqlx"));
         assert!(project.dependencies.contains_key("chrono"));
     }
-    
+
     #[test]
     fn test_api_database_auth_combination() {
         let mut project = ProjectWithFeatures::new("secure-api", vec!["api", "database", "auth"]);
         let files = project.generate_project_structure();
-        
+
         // Should have all feature files
         assert!(files.iter().any(|f| f.to_str().unwrap().contains("routes")));
         assert!(files.iter().any(|f| f.to_str().unwrap().contains("db.rs")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("auth/jwt.rs")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("auth/middleware.rs")));
-        
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("auth/jwt.rs")));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("auth/middleware.rs")));
+
         // Should have all dependencies
         assert!(project.dependencies.contains_key("axum"));
         assert!(project.dependencies.contains_key("sqlx"));
         assert!(project.dependencies.contains_key("jsonwebtoken"));
         assert!(project.dependencies.contains_key("argon2"));
     }
-    
+
     #[test]
     fn test_auth_with_oauth_sub_feature() {
         let mut project = ProjectWithFeatures::new("oauth-app", vec!["api", "auth", "oauth"]);
         let files = project.generate_project_structure();
-        
+
         // Should have OAuth files
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains("auth/oauth.rs")));
-        
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains("auth/oauth.rs")));
+
         // Should have OAuth dependencies
         assert!(project.dependencies.contains_key("oauth2"));
         assert!(project.dependencies.contains_key("reqwest"));
     }
-    
+
     #[test]
     fn test_docker_integration() {
-        let mut project = ProjectWithFeatures::new("dockerized-app", vec!["api", "database", "docker"]);
+        let mut project =
+            ProjectWithFeatures::new("dockerized-app", vec!["api", "database", "docker"]);
         let files = project.generate_project_structure();
-        
+
         // Should have Docker files
         assert!(files.iter().any(|f| f.to_str().unwrap() == "Dockerfile"));
-        assert!(files.iter().any(|f| f.to_str().unwrap() == "docker-compose.yml"));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap() == "docker-compose.yml"));
         assert!(files.iter().any(|f| f.to_str().unwrap() == ".dockerignore"));
-        assert!(files.iter().any(|f| f.to_str().unwrap() == "docker-compose.dev.yml"));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap() == "docker-compose.dev.yml"));
     }
-    
+
     #[test]
     fn test_docker_compose_generation() {
-        let project = ProjectWithFeatures::new("test-app", vec!["api", "database", "auth", "docker"]);
+        let project =
+            ProjectWithFeatures::new("test-app", vec!["api", "database", "auth", "docker"]);
         let compose = project.generate_docker_compose();
-        
+
         // Should have main app service
         assert!(compose.contains("test-app:"));
         assert!(compose.contains("build: ."));
-        
+
         // Should have postgres service
         assert!(compose.contains("postgres:"));
         assert!(compose.contains("postgres:15"));
         assert!(compose.contains("POSTGRES_PASSWORD"));
-        
+
         // Should have redis service for auth
         assert!(compose.contains("redis:"));
         assert!(compose.contains("redis:7-alpine"));
-        
+
         // Should have volumes
         assert!(compose.contains("volumes:"));
         assert!(compose.contains("postgres_data:"));
     }
-    
+
     #[test]
     fn test_ci_integration() {
         let mut project = ProjectWithFeatures::new("ci-app", vec!["api", "ci"]);
         let files = project.generate_project_structure();
-        
+
         // Should have CI files
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains(".github/workflows/ci.yml")));
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains(".github/workflows/release.yml")));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains(".github/workflows/ci.yml")));
+        assert!(files.iter().any(|f| f
+            .to_str()
+            .unwrap()
+            .contains(".github/workflows/release.yml")));
     }
-    
+
     #[test]
     fn test_ci_with_docker() {
         let mut project = ProjectWithFeatures::new("ci-docker-app", vec!["api", "ci", "docker"]);
         let files = project.generate_project_structure();
-        
+
         // Should have Docker CI workflow
-        assert!(files.iter().any(|f| f.to_str().unwrap().contains(".github/workflows/docker.yml")));
+        assert!(files
+            .iter()
+            .any(|f| f.to_str().unwrap().contains(".github/workflows/docker.yml")));
     }
-    
+
     #[test]
     fn test_complete_feature_combination() {
-        let mut project = ProjectWithFeatures::new("complete-app", vec![
-            "api", "database", "auth", "oauth", "docker", "ci"
-        ]);
+        let mut project = ProjectWithFeatures::new(
+            "complete-app",
+            vec!["api", "database", "auth", "oauth", "docker", "ci"],
+        );
         let files = project.generate_project_structure();
-        
+
         // Count total files - should have many
         assert!(files.len() > 25, "Complete project should have many files");
-        
+
         // Verify all major components are present
-        let file_paths: Vec<String> = files.iter()
+        let file_paths: Vec<String> = files
+            .iter()
             .map(|p| p.to_str().unwrap().to_string())
             .collect();
-        
+
         // API files
         assert!(file_paths.iter().any(|f| f.contains("routes")));
         assert!(file_paths.iter().any(|f| f.contains("handlers")));
-        
+
         // Database files
         assert!(file_paths.iter().any(|f| f.contains("migrations")));
         assert!(file_paths.iter().any(|f| f.contains("db.rs")));
-        
+
         // Auth files
         assert!(file_paths.iter().any(|f| f.contains("auth/jwt.rs")));
         assert!(file_paths.iter().any(|f| f.contains("auth/oauth.rs")));
-        
+
         // Docker files
         assert!(file_paths.iter().any(|f| f == "Dockerfile"));
         assert!(file_paths.iter().any(|f| f == "docker-compose.yml"));
-        
+
         // CI files
         assert!(file_paths.iter().any(|f| f.contains(".github/workflows")));
-        
+
         // Validate dependencies
         assert!(project.validate_dependencies().is_ok());
     }
-    
+
     #[test]
     fn test_minimal_vs_maximal_projects() {
         let minimal = ProjectWithFeatures::new("minimal", vec![]);
-        let maximal = ProjectWithFeatures::new("maximal", vec![
-            "api", "database", "auth", "oauth", "docker", "ci"
-        ]);
-        
+        let maximal = ProjectWithFeatures::new(
+            "maximal",
+            vec!["api", "database", "auth", "oauth", "docker", "ci"],
+        );
+
         let mut minimal_mut = minimal;
         let mut maximal_mut = maximal;
-        
+
         let minimal_files = minimal_mut.generate_project_structure();
         let maximal_files = maximal_mut.generate_project_structure();
-        
+
         // Minimal should have only base files
         assert!(minimal_files.len() < 10);
-        
+
         // Maximal should have many more files
         assert!(maximal_files.len() > 25);
-        
+
         // Maximal should have way more dependencies
         assert!(minimal_mut.dependencies.is_empty());
         assert!(maximal_mut.dependencies.len() > 10);

--- a/tests/feature_integration_test.rs
+++ b/tests/feature_integration_test.rs
@@ -14,6 +14,8 @@ fn test_docker_feature_generates_files() {
         author: "Test Author".to_string(),
         description: Some("Test API with Docker".to_string()),
         features: vec!["docker".to_string()],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -52,6 +54,8 @@ fn test_ci_feature_generates_files() {
         author: "Test Author".to_string(),
         description: Some("Test CLI with CI".to_string()),
         features: vec!["ci".to_string()],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -75,6 +79,8 @@ fn test_database_feature_generates_files() {
         author: "Test Author".to_string(),
         description: Some("Test API with Database".to_string()),
         features: vec!["database".to_string()],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -106,6 +112,8 @@ fn test_multiple_features() {
             "ci".to_string(),
             "database".to_string(),
         ],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();

--- a/tests/feature_integration_test.rs
+++ b/tests/feature_integration_test.rs
@@ -1,13 +1,13 @@
 use cargo_forge::{Generator, ProjectConfig};
-use std::path::Path;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
 
 #[test]
 fn test_docker_feature_generates_files() {
     let temp_dir = TempDir::new().unwrap();
     let project_path = temp_dir.path().join("test-docker-api");
-    
+
     let config = ProjectConfig {
         name: "test-docker-api".to_string(),
         project_type: "api-server".to_string(),
@@ -15,25 +15,37 @@ fn test_docker_feature_generates_files() {
         description: Some("Test API with Docker".to_string()),
         features: vec!["docker".to_string()],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &project_path).unwrap();
-    
+
     // Check that Docker files were created
-    assert!(project_path.join("Dockerfile").exists(), "Dockerfile should be created");
-    assert!(project_path.join(".dockerignore").exists(), ".dockerignore should be created");
-    assert!(project_path.join("scripts/docker-build.sh").exists(), "docker-build.sh script should be created");
-    
+    assert!(
+        project_path.join("Dockerfile").exists(),
+        "Dockerfile should be created"
+    );
+    assert!(
+        project_path.join(".dockerignore").exists(),
+        ".dockerignore should be created"
+    );
+    assert!(
+        project_path.join("scripts/docker-build.sh").exists(),
+        "docker-build.sh script should be created"
+    );
+
     // Check that the README contains Docker section
     let readme_content = fs::read_to_string(project_path.join("README.md")).unwrap();
-    assert!(readme_content.contains("Docker Support"), "README should contain Docker section");
+    assert!(
+        readme_content.contains("Docker Support"),
+        "README should contain Docker section"
+    );
 }
 
 #[test]
 fn test_ci_feature_generates_files() {
     let temp_dir = TempDir::new().unwrap();
     let project_path = temp_dir.path().join("test-ci-cli");
-    
+
     let config = ProjectConfig {
         name: "test-ci-cli".to_string(),
         project_type: "cli-tool".to_string(),
@@ -41,19 +53,22 @@ fn test_ci_feature_generates_files() {
         description: Some("Test CLI with CI".to_string()),
         features: vec!["ci".to_string()],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &project_path).unwrap();
-    
+
     // Check that CI files were created
-    assert!(project_path.join(".github/workflows/ci.yml").exists(), "GitHub Actions CI workflow should be created");
+    assert!(
+        project_path.join(".github/workflows/ci.yml").exists(),
+        "GitHub Actions CI workflow should be created"
+    );
 }
 
 #[test]
 fn test_database_feature_generates_files() {
     let temp_dir = TempDir::new().unwrap();
     let project_path = temp_dir.path().join("test-database-api");
-    
+
     let config = ProjectConfig {
         name: "test-database-api".to_string(),
         project_type: "api-server".to_string(),
@@ -61,34 +76,56 @@ fn test_database_feature_generates_files() {
         description: Some("Test API with Database".to_string()),
         features: vec!["database".to_string()],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &project_path).unwrap();
-    
+
     // Check that database files were created
-    assert!(project_path.join("src/database.rs").exists(), "database.rs should be created");
-    assert!(project_path.join("migrations").exists(), "migrations directory should be created");
+    assert!(
+        project_path.join("src/database.rs").exists(),
+        "database.rs should be created"
+    );
+    assert!(
+        project_path.join("migrations").exists(),
+        "migrations directory should be created"
+    );
 }
 
 #[test]
 fn test_multiple_features() {
     let temp_dir = TempDir::new().unwrap();
     let project_path = temp_dir.path().join("test-full-api");
-    
+
     let config = ProjectConfig {
         name: "test-full-api".to_string(),
         project_type: "api-server".to_string(),
         author: "Test Author".to_string(),
         description: Some("Test API with all features".to_string()),
-        features: vec!["docker".to_string(), "ci".to_string(), "database".to_string()],
+        features: vec![
+            "docker".to_string(),
+            "ci".to_string(),
+            "database".to_string(),
+        ],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &project_path).unwrap();
-    
+
     // Check that all feature files were created
-    assert!(project_path.join("Dockerfile").exists(), "Dockerfile should be created");
-    assert!(project_path.join(".github/workflows/ci.yml").exists(), "CI workflow should be created");
-    assert!(project_path.join("src/database.rs").exists(), "database.rs should be created");
-    assert!(project_path.join("migrations").exists(), "migrations directory should be created");
+    assert!(
+        project_path.join("Dockerfile").exists(),
+        "Dockerfile should be created"
+    );
+    assert!(
+        project_path.join(".github/workflows/ci.yml").exists(),
+        "CI workflow should be created"
+    );
+    assert!(
+        project_path.join("src/database.rs").exists(),
+        "database.rs should be created"
+    );
+    assert!(
+        project_path.join("migrations").exists(),
+        "migrations directory should be created"
+    );
 }

--- a/tests/features_test.rs
+++ b/tests/features_test.rs
@@ -1,4 +1,4 @@
-use cargo_forge::{ProjectContext, features::*};
+use cargo_forge::{features::*, ProjectContext};
 
 #[test]
 fn test_plugin_manager_new() {
@@ -9,7 +9,9 @@ fn test_plugin_manager_new() {
 #[test]
 fn test_plugin_manager_register() {
     let mut manager = PluginManager::new();
-    let database_plugin = Box::new(database::DatabasePlugin::new(database::DatabaseType::PostgreSQL));
+    let database_plugin = Box::new(database::DatabasePlugin::new(
+        database::DatabaseType::PostgreSQL,
+    ));
     manager.register(database_plugin);
     assert_eq!(manager.len(), 1);
 }
@@ -18,10 +20,10 @@ fn test_plugin_manager_register() {
 fn test_database_plugin_postgresql() {
     let plugin = database::DatabasePlugin::new(database::DatabaseType::PostgreSQL);
     assert_eq!(plugin.name(), "Database");
-    
+
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.dependencies.contains_key("sqlx"));
     assert!(context.dependencies.contains_key("tokio"));
     assert!(context.dependencies.contains_key("dotenv"));
@@ -34,7 +36,7 @@ fn test_database_plugin_sqlite() {
     let plugin = database::DatabasePlugin::new(database::DatabaseType::SQLite);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     let sqlx_dep = context.dependencies.get("sqlx").unwrap();
     assert!(sqlx_dep.contains("sqlite"));
     assert!(!sqlx_dep.contains("postgres"));
@@ -46,7 +48,7 @@ fn test_database_plugin_mysql() {
     let plugin = database::DatabasePlugin::new(database::DatabaseType::MySQL);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     let sqlx_dep = context.dependencies.get("sqlx").unwrap();
     assert!(sqlx_dep.contains("mysql"));
     assert!(!sqlx_dep.contains("postgres"));
@@ -55,37 +57,40 @@ fn test_database_plugin_mysql() {
 
 #[test]
 fn test_database_plugin_with_migrations() {
-    let plugin = database::DatabasePlugin::new(database::DatabaseType::PostgreSQL)
-        .with_migrations(true);
+    let plugin =
+        database::DatabasePlugin::new(database::DatabaseType::PostgreSQL).with_migrations(true);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.directories.contains(&"migrations".to_string()));
-    assert!(context.template_files.contains_key("migrations/001_create_users_table.sql"));
+    assert!(context
+        .template_files
+        .contains_key("migrations/001_create_users_table.sql"));
     assert!(context.template_files.contains_key("migrations/.gitkeep"));
 }
 
 #[test]
 fn test_database_plugin_without_migrations() {
-    let plugin = database::DatabasePlugin::new(database::DatabaseType::PostgreSQL)
-        .with_migrations(false);
+    let plugin =
+        database::DatabasePlugin::new(database::DatabaseType::PostgreSQL).with_migrations(false);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(!context.directories.contains(&"migrations".to_string()));
 }
 
 #[test]
 fn test_docker_plugin_simple() {
-    let plugin = docker::DockerPlugin::new()
-        .with_build_stage(docker::DockerBuildStage::Simple);
+    let plugin = docker::DockerPlugin::new().with_build_stage(docker::DockerBuildStage::Simple);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.template_files.contains_key("Dockerfile"));
     assert!(context.template_files.contains_key(".dockerignore"));
-    assert!(context.template_files.contains_key("scripts/docker-build.sh"));
-    
+    assert!(context
+        .template_files
+        .contains_key("scripts/docker-build.sh"));
+
     let dockerfile = context.template_files.get("Dockerfile").unwrap();
     assert!(dockerfile.contains("FROM rust:1.75-slim"));
     assert!(!dockerfile.contains("FROM rust:1.75 AS builder"));
@@ -93,11 +98,10 @@ fn test_docker_plugin_simple() {
 
 #[test]
 fn test_docker_plugin_multistage() {
-    let plugin = docker::DockerPlugin::new()
-        .with_build_stage(docker::DockerBuildStage::MultiStage);
+    let plugin = docker::DockerPlugin::new().with_build_stage(docker::DockerBuildStage::MultiStage);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     let dockerfile = context.template_files.get("Dockerfile").unwrap();
     assert!(dockerfile.contains("FROM rust:1.75 AS builder"));
     assert!(dockerfile.contains("FROM debian:bookworm-slim"));
@@ -105,11 +109,11 @@ fn test_docker_plugin_multistage() {
 
 #[test]
 fn test_docker_plugin_with_cache() {
-    let plugin = docker::DockerPlugin::new()
-        .with_build_stage(docker::DockerBuildStage::MultiStageWithCache);
+    let plugin =
+        docker::DockerPlugin::new().with_build_stage(docker::DockerBuildStage::MultiStageWithCache);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     let dockerfile = context.template_files.get("Dockerfile").unwrap();
     assert!(dockerfile.contains("cargo-chef"));
     assert!(dockerfile.contains("recipe.json"));
@@ -122,10 +126,12 @@ fn test_docker_plugin_with_compose() {
         .expose_port(3000);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.template_files.contains_key("docker-compose.yml"));
-    assert!(context.template_files.contains_key("scripts/docker-compose-start.sh"));
-    
+    assert!(context
+        .template_files
+        .contains_key("scripts/docker-compose-start.sh"));
+
     let compose = context.template_files.get("docker-compose.yml").unwrap();
     assert!(compose.contains("version: '3.8'"));
     assert!(compose.contains("3000:3000"));
@@ -136,12 +142,19 @@ fn test_ci_plugin_github_actions() {
     let plugin = ci::CIPlugin::new(ci::CIPlatform::GitHubActions);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
-    assert!(context.directories.contains(&".github/workflows".to_string()));
-    assert!(context.template_files.contains_key(".github/workflows/ci.yml"));
+
+    assert!(context
+        .directories
+        .contains(&".github/workflows".to_string()));
+    assert!(context
+        .template_files
+        .contains_key(".github/workflows/ci.yml"));
     assert!(!context.template_files.contains_key(".gitlab-ci.yml"));
-    
-    let workflow = context.template_files.get(".github/workflows/ci.yml").unwrap();
+
+    let workflow = context
+        .template_files
+        .get(".github/workflows/ci.yml")
+        .unwrap();
     assert!(workflow.contains("name: CI"));
     assert!(workflow.contains("uses: actions/checkout"));
 }
@@ -151,10 +164,12 @@ fn test_ci_plugin_gitlab() {
     let plugin = ci::CIPlugin::new(ci::CIPlatform::GitLabCI);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.template_files.contains_key(".gitlab-ci.yml"));
-    assert!(!context.template_files.contains_key(".github/workflows/ci.yml"));
-    
+    assert!(!context
+        .template_files
+        .contains_key(".github/workflows/ci.yml"));
+
     let ci_config = context.template_files.get(".gitlab-ci.yml").unwrap();
     assert!(ci_config.contains("stages:"));
     assert!(ci_config.contains("test:cargo:"));
@@ -165,8 +180,10 @@ fn test_ci_plugin_both_platforms() {
     let plugin = ci::CIPlugin::new(ci::CIPlatform::Both);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
-    assert!(context.template_files.contains_key(".github/workflows/ci.yml"));
+
+    assert!(context
+        .template_files
+        .contains_key(".github/workflows/ci.yml"));
     assert!(context.template_files.contains_key(".gitlab-ci.yml"));
 }
 
@@ -178,8 +195,11 @@ fn test_ci_plugin_with_features() {
         .with_release(true);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
-    let workflow = context.template_files.get(".github/workflows/ci.yml").unwrap();
+
+    let workflow = context
+        .template_files
+        .get(".github/workflows/ci.yml")
+        .unwrap();
     assert!(workflow.contains("coverage:"));
     assert!(workflow.contains("security_audit:"));
     assert!(workflow.contains("release:"));
@@ -195,8 +215,11 @@ fn test_ci_plugin_without_features() {
         .with_release(false);
     let mut context = ProjectContext::new("test_project");
     plugin.configure(&mut context).unwrap();
-    
-    let workflow = context.template_files.get(".github/workflows/ci.yml").unwrap();
+
+    let workflow = context
+        .template_files
+        .get(".github/workflows/ci.yml")
+        .unwrap();
     assert!(!workflow.contains("coverage:"));
     assert!(!workflow.contains("security_audit:"));
     assert!(!workflow.contains("release:"));
@@ -205,18 +228,26 @@ fn test_ci_plugin_without_features() {
 #[test]
 fn test_multiple_plugins_integration() {
     let mut manager = PluginManager::new();
-    
-    manager.register(Box::new(database::DatabasePlugin::new(database::DatabaseType::PostgreSQL)));
-    manager.register(Box::new(docker::DockerPlugin::new().with_compose(true).expose_port(8080)));
+
+    manager.register(Box::new(database::DatabasePlugin::new(
+        database::DatabaseType::PostgreSQL,
+    )));
+    manager.register(Box::new(
+        docker::DockerPlugin::new()
+            .with_compose(true)
+            .expose_port(8080),
+    ));
     manager.register(Box::new(ci::CIPlugin::new(ci::CIPlatform::Both)));
-    
+
     let mut context = ProjectContext::new("test_integration");
     manager.configure_all(&mut context).unwrap();
-    
+
     assert!(context.dependencies.contains_key("sqlx"));
     assert!(context.template_files.contains_key("Dockerfile"));
     assert!(context.template_files.contains_key("docker-compose.yml"));
-    assert!(context.template_files.contains_key(".github/workflows/ci.yml"));
+    assert!(context
+        .template_files
+        .contains_key(".github/workflows/ci.yml"));
     assert!(context.template_files.contains_key(".gitlab-ci.yml"));
     assert!(context.template_files.contains_key("src/database.rs"));
 }
@@ -224,15 +255,15 @@ fn test_multiple_plugins_integration() {
 #[test]
 fn test_plugin_readme_integration() {
     let mut context = ProjectContext::new("test_readme");
-    
+
     let db_plugin = database::DatabasePlugin::new(database::DatabaseType::SQLite);
     let docker_plugin = docker::DockerPlugin::new();
     let ci_plugin = ci::CIPlugin::new(ci::CIPlatform::GitHubActions);
-    
+
     db_plugin.configure(&mut context).unwrap();
     docker_plugin.configure(&mut context).unwrap();
     ci_plugin.configure(&mut context).unwrap();
-    
+
     let readme = &context.readme_sections.join("\n");
     assert!(readme.contains("Docker Support"));
     assert!(readme.contains("CI/CD"));
@@ -241,10 +272,10 @@ fn test_plugin_readme_integration() {
 #[test]
 fn test_plugin_gitignore_entries() {
     let mut context = ProjectContext::new("test_gitignore");
-    
+
     let db_plugin = database::DatabasePlugin::new(database::DatabaseType::SQLite);
     db_plugin.configure(&mut context).unwrap();
-    
+
     assert!(context.gitignore_entries.contains(&".env".to_string()));
     assert!(context.gitignore_entries.contains(&"*.db".to_string()));
     assert!(context.gitignore_entries.contains(&"*.db-shm".to_string()));

--- a/tests/forge_test.rs
+++ b/tests/forge_test.rs
@@ -7,13 +7,16 @@ fn test_interactive_flow() {
     // This test should fail as Forge struct doesn't exist yet
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Simulate user input for interactive flow
     let input = "1\nmy-awesome-project\n";
     let mut cursor = Cursor::new(input);
-    
+
     let result = forge.run_interactive(&mut cursor);
-    assert!(result.is_ok(), "Interactive flow should complete successfully");
+    assert!(
+        result.is_ok(),
+        "Interactive flow should complete successfully"
+    );
 }
 
 #[test]
@@ -21,32 +24,32 @@ fn test_user_can_select_project_type() {
     // This test should fail as the functionality doesn't exist yet
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Test selecting API Server (option 1)
     let input = "1\n";
     let mut cursor = Cursor::new(input);
-    
+
     let project_type = forge.prompt_project_type(&mut cursor).unwrap();
     assert_eq!(project_type, ProjectType::ApiServer);
-    
+
     // Test selecting CLI Tool (option 2)
     let input = "2\n";
     let mut cursor = Cursor::new(input);
-    
+
     let project_type = forge.prompt_project_type(&mut cursor).unwrap();
     assert_eq!(project_type, ProjectType::CliTool);
-    
+
     // Test selecting Library (option 3)
     let input = "3\n";
     let mut cursor = Cursor::new(input);
-    
+
     let project_type = forge.prompt_project_type(&mut cursor).unwrap();
     assert_eq!(project_type, ProjectType::Library);
-    
+
     // Test selecting WASM App (option 4)
     let input = "4\n";
     let mut cursor = Cursor::new(input);
-    
+
     let project_type = forge.prompt_project_type(&mut cursor).unwrap();
     assert_eq!(project_type, ProjectType::WasmApp);
 }
@@ -56,13 +59,13 @@ fn test_project_name_validation() {
     // This test should fail as the validation doesn't exist yet
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Test valid project names
     assert!(forge.validate_project_name("my-project").is_ok());
     assert!(forge.validate_project_name("my_project").is_ok());
     assert!(forge.validate_project_name("myproject123").is_ok());
     assert!(forge.validate_project_name("a").is_ok());
-    
+
     // Test invalid project names
     assert!(forge.validate_project_name("").is_err());
     assert!(forge.validate_project_name("My-Project").is_err()); // No capitals
@@ -78,11 +81,11 @@ fn test_interactive_flow_with_invalid_input() {
     // Test handling of invalid inputs
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Invalid project type selection
     let input = "99\n1\nvalid-project\n";
     let mut cursor = Cursor::new(input);
-    
+
     let result = forge.run_interactive(&mut cursor);
     assert!(result.is_ok(), "Should recover from invalid input");
 }
@@ -92,12 +95,12 @@ fn test_interactive_flow_creates_project_directory() {
     // Test that the interactive flow creates the project directory
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     let input = "1\ntest-project\n";
     let mut cursor = Cursor::new(input);
-    
+
     forge.run_interactive(&mut cursor).unwrap();
-    
+
     let project_path = temp_dir.path().join("test-project");
     assert!(project_path.exists(), "Project directory should be created");
     assert!(project_path.is_dir(), "Project path should be a directory");

--- a/tests/generator_test.rs
+++ b/tests/generator_test.rs
@@ -8,7 +8,7 @@ fn test_file_generation_functionality() {
     // This test should fail as Generator doesn't exist yet
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("test-project");
-    
+
     let config = ProjectConfig {
         name: "test-project".to_string(),
         project_type: "api-server".to_string(),
@@ -16,10 +16,10 @@ fn test_file_generation_functionality() {
         description: Some("Test description".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     let result = generator.generate(&config, &output_dir);
-    
+
     assert!(result.is_ok(), "File generation should succeed");
     assert!(output_dir.exists(), "Output directory should be created");
 }
@@ -29,7 +29,7 @@ fn test_directory_creation() {
     // Test that all necessary directories are created
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("test-project");
-    
+
     let config = ProjectConfig {
         name: "test-project".to_string(),
         project_type: "library".to_string(),
@@ -37,19 +37,34 @@ fn test_directory_creation() {
         description: None,
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check standard Rust project structure
-    assert!(output_dir.join("src").exists(), "src directory should exist");
+    assert!(
+        output_dir.join("src").exists(),
+        "src directory should exist"
+    );
     assert!(output_dir.join("src").is_dir(), "src should be a directory");
-    
-    assert!(output_dir.join("tests").exists(), "tests directory should exist");
-    assert!(output_dir.join("tests").is_dir(), "tests should be a directory");
-    
-    assert!(output_dir.join("Cargo.toml").exists(), "Cargo.toml should exist");
-    assert!(output_dir.join("Cargo.toml").is_file(), "Cargo.toml should be a file");
+
+    assert!(
+        output_dir.join("tests").exists(),
+        "tests directory should exist"
+    );
+    assert!(
+        output_dir.join("tests").is_dir(),
+        "tests should be a directory"
+    );
+
+    assert!(
+        output_dir.join("Cargo.toml").exists(),
+        "Cargo.toml should exist"
+    );
+    assert!(
+        output_dir.join("Cargo.toml").is_file(),
+        "Cargo.toml should be a file"
+    );
 }
 
 #[test]
@@ -57,7 +72,7 @@ fn test_proper_permissions() {
     // Test that files and directories have proper permissions
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("test-project");
-    
+
     let config = ProjectConfig {
         name: "test-project".to_string(),
         project_type: "cli-tool".to_string(),
@@ -65,19 +80,25 @@ fn test_proper_permissions() {
         description: Some("A CLI tool".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check directory permissions (should be readable and executable)
     let src_metadata = fs::metadata(output_dir.join("src")).unwrap();
     let src_permissions = src_metadata.permissions();
-    assert!(src_permissions.mode() & 0o755 >= 0o755, "src directory should have proper permissions");
-    
+    assert!(
+        src_permissions.mode() & 0o755 >= 0o755,
+        "src directory should have proper permissions"
+    );
+
     // Check file permissions (should be readable)
     let cargo_metadata = fs::metadata(output_dir.join("Cargo.toml")).unwrap();
     let cargo_permissions = cargo_metadata.permissions();
-    assert!(cargo_permissions.mode() & 0o644 >= 0o644, "Cargo.toml should have proper permissions");
+    assert!(
+        cargo_permissions.mode() & 0o644 >= 0o644,
+        "Cargo.toml should have proper permissions"
+    );
 }
 
 #[test]
@@ -85,11 +106,11 @@ fn test_overwrite_protection() {
     // Test that generator doesn't overwrite existing projects by default
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("test-project");
-    
+
     // Create directory with existing file
     fs::create_dir_all(&output_dir).unwrap();
     fs::write(output_dir.join("existing.txt"), "existing content").unwrap();
-    
+
     let config = ProjectConfig {
         name: "test-project".to_string(),
         project_type: "library".to_string(),
@@ -97,12 +118,15 @@ fn test_overwrite_protection() {
         description: None,
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     let result = generator.generate(&config, &output_dir);
-    
+
     // Should fail or warn about existing directory
-    assert!(result.is_err() || fs::read_to_string(output_dir.join("existing.txt")).unwrap() == "existing content");
+    assert!(
+        result.is_err()
+            || fs::read_to_string(output_dir.join("existing.txt")).unwrap() == "existing content"
+    );
 }
 
 #[test]
@@ -110,7 +134,7 @@ fn test_template_variable_injection() {
     // Test that template variables are properly injected into generated files
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("variable-test");
-    
+
     let config = ProjectConfig {
         name: "variable-test".to_string(),
         project_type: "api-server".to_string(),
@@ -118,22 +142,31 @@ fn test_template_variable_injection() {
         description: Some("A test API server".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Read generated Cargo.toml and check for injected variables
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("variable-test"), "Project name should be in Cargo.toml");
-    assert!(cargo_content.contains("John Doe"), "Author should be in Cargo.toml");
-    assert!(cargo_content.contains("A test API server"), "Description should be in Cargo.toml");
+    assert!(
+        cargo_content.contains("variable-test"),
+        "Project name should be in Cargo.toml"
+    );
+    assert!(
+        cargo_content.contains("John Doe"),
+        "Author should be in Cargo.toml"
+    );
+    assert!(
+        cargo_content.contains("A test API server"),
+        "Description should be in Cargo.toml"
+    );
 }
 
 #[test]
 fn test_binary_vs_library_generation() {
     // Test different file generation for binary vs library projects
     let temp_dir = TempDir::new().unwrap();
-    
+
     // Test library generation
     let lib_dir = temp_dir.path().join("lib-project");
     let lib_config = ProjectConfig {
@@ -143,13 +176,19 @@ fn test_binary_vs_library_generation() {
         description: None,
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&lib_config, &lib_dir).unwrap();
-    
-    assert!(lib_dir.join("src/lib.rs").exists(), "Library should have lib.rs");
-    assert!(!lib_dir.join("src/main.rs").exists(), "Library should not have main.rs");
-    
+
+    assert!(
+        lib_dir.join("src/lib.rs").exists(),
+        "Library should have lib.rs"
+    );
+    assert!(
+        !lib_dir.join("src/main.rs").exists(),
+        "Library should not have main.rs"
+    );
+
     // Test binary generation
     let bin_dir = temp_dir.path().join("bin-project");
     let bin_config = ProjectConfig {
@@ -159,11 +198,17 @@ fn test_binary_vs_library_generation() {
         description: None,
         features: vec![],
     };
-    
+
     generator.generate(&bin_config, &bin_dir).unwrap();
-    
-    assert!(bin_dir.join("src/main.rs").exists(), "Binary should have main.rs");
-    assert!(!bin_dir.join("src/lib.rs").exists(), "Binary should not have lib.rs by default");
+
+    assert!(
+        bin_dir.join("src/main.rs").exists(),
+        "Binary should have main.rs"
+    );
+    assert!(
+        !bin_dir.join("src/lib.rs").exists(),
+        "Binary should not have lib.rs by default"
+    );
 }
 
 #[test]
@@ -171,7 +216,7 @@ fn test_gitignore_generation() {
     // Test that .gitignore is properly generated
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("git-test");
-    
+
     let config = ProjectConfig {
         name: "git-test".to_string(),
         project_type: "library".to_string(),
@@ -179,16 +224,22 @@ fn test_gitignore_generation() {
         description: None,
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     let gitignore_path = output_dir.join(".gitignore");
     assert!(gitignore_path.exists(), ".gitignore should be generated");
-    
+
     let gitignore_content = fs::read_to_string(gitignore_path).unwrap();
-    assert!(gitignore_content.contains("/target"), ".gitignore should contain /target");
-    assert!(gitignore_content.contains("Cargo.lock"), ".gitignore should contain Cargo.lock for libraries");
+    assert!(
+        gitignore_content.contains("/target"),
+        ".gitignore should contain /target"
+    );
+    assert!(
+        gitignore_content.contains("Cargo.lock"),
+        ".gitignore should contain Cargo.lock for libraries"
+    );
 }
 
 #[test]
@@ -196,7 +247,7 @@ fn test_readme_generation() {
     // Test that README.md is properly generated
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("readme-test");
-    
+
     let config = ProjectConfig {
         name: "readme-test".to_string(),
         project_type: "api-server".to_string(),
@@ -204,14 +255,20 @@ fn test_readme_generation() {
         description: Some("An awesome API server".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     let readme_path = output_dir.join("README.md");
     assert!(readme_path.exists(), "README.md should be generated");
-    
+
     let readme_content = fs::read_to_string(readme_path).unwrap();
-    assert!(readme_content.contains("readme-test"), "README should contain project name");
-    assert!(readme_content.contains("An awesome API server"), "README should contain description");
+    assert!(
+        readme_content.contains("readme-test"),
+        "README should contain project name"
+    );
+    assert!(
+        readme_content.contains("An awesome API server"),
+        "README should contain description"
+    );
 }

--- a/tests/generator_test.rs
+++ b/tests/generator_test.rs
@@ -15,6 +15,8 @@ fn test_file_generation_functionality() {
         author: "Test Author".to_string(),
         description: Some("Test description".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -36,6 +38,8 @@ fn test_directory_creation() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -79,6 +83,8 @@ fn test_proper_permissions() {
         author: "Test Author".to_string(),
         description: Some("A CLI tool".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -117,6 +123,8 @@ fn test_overwrite_protection() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -141,6 +149,8 @@ fn test_template_variable_injection() {
         author: "John Doe".to_string(),
         description: Some("A test API server".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -175,6 +185,8 @@ fn test_binary_vs_library_generation() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -197,6 +209,8 @@ fn test_binary_vs_library_generation() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     generator.generate(&bin_config, &bin_dir).unwrap();
@@ -223,6 +237,8 @@ fn test_gitignore_generation() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -254,6 +270,8 @@ fn test_readme_generation() {
         author: "Test Author".to_string(),
         description: Some("An awesome API server".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ fn run_cargo_check(project_dir: &Path) -> Result<bool, String> {
 fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<(), String> {
     let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read file {:?}: {}", file_path, e))?;
-    
+
     for expected in expected_contents {
         if !content.contains(expected) {
             return Err(format!(
@@ -49,18 +49,14 @@ fn verify_file_contains(file_path: &Path, expected_contents: &[&str]) -> Result<
             ));
         }
     }
-    
+
     Ok(())
 }
 
 // Helper function to verify all common files exist
 fn verify_common_files(project_dir: &Path) -> Result<(), String> {
-    let required_files = vec![
-        "Cargo.toml",
-        "README.md",
-        ".gitignore",
-    ];
-    
+    let required_files = vec!["Cargo.toml", "README.md", ".gitignore"];
+
     for file in required_files {
         let file_path = project_dir.join(file);
         if !file_path.exists() {
@@ -70,9 +66,9 @@ fn verify_common_files(project_dir: &Path) -> Result<(), String> {
             return Err(format!("'{}' is not a file", file));
         }
     }
-    
+
     let required_dirs = vec!["src", "tests"];
-    
+
     for dir in required_dirs {
         let dir_path = project_dir.join(dir);
         if !dir_path.exists() {
@@ -82,7 +78,7 @@ fn verify_common_files(project_dir: &Path) -> Result<(), String> {
             return Err(format!("'{}' is not a directory", dir));
         }
     }
-    
+
     Ok(())
 }
 
@@ -91,17 +87,17 @@ fn test_api_server_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-api-server");
     let config = create_test_config("test-api-server", "api-server");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate API server project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify API server specific files
     let api_files = vec![
         "src/main.rs",
@@ -111,13 +107,17 @@ fn test_api_server_integration() {
         "config/default.toml",
         ".env.example",
     ];
-    
+
     for file in api_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "API server file '{}' does not exist", file);
+        assert!(
+            file_path.exists(),
+            "API server file '{}' does not exist",
+            file
+        );
         assert!(file_path.is_file(), "'{}' is not a file", file);
     }
-    
+
     // Verify Cargo.toml contains correct dependencies
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -130,8 +130,9 @@ fn test_api_server_integration() {
             "serde",
             "tower",
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -141,8 +142,9 @@ fn test_api_server_integration() {
             "API Server",
             "http://localhost:3000",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the project compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("API server project compiles successfully"),
@@ -155,33 +157,36 @@ fn test_cli_tool_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-cli-tool");
     let config = create_test_config("test-cli-tool", "cli-tool");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate CLI tool project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify CLI tool specific files
-    let cli_files = vec![
-        "src/main.rs",
-        "src/cli.rs",
-        "src/commands.rs",
-    ];
-    
+    let cli_files = vec!["src/main.rs", "src/cli.rs", "src/commands.rs"];
+
     for file in cli_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "CLI tool file '{}' does not exist", file);
+        assert!(
+            file_path.exists(),
+            "CLI tool file '{}' does not exist",
+            file
+        );
         assert!(file_path.is_file(), "'{}' is not a file", file);
     }
-    
+
     // Verify no lib.rs exists (should be binary only)
-    assert!(!project_dir.join("src/lib.rs").exists(), "CLI tool should not have lib.rs");
-    
+    assert!(
+        !project_dir.join("src/lib.rs").exists(),
+        "CLI tool should not have lib.rs"
+    );
+
     // Verify Cargo.toml contains correct dependencies and binary section
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -195,8 +200,9 @@ fn test_cli_tool_integration() {
             "[[bin]]",
             "path = \"src/main.rs\"",
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -206,8 +212,9 @@ fn test_cli_tool_integration() {
             "CLI Tool",
             "cargo run -- --help",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the project compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("CLI tool project compiles successfully"),
@@ -220,29 +227,42 @@ fn test_library_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-library");
     let config = create_test_config("test-library", "library");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate library project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify library specific files
-    assert!(project_dir.join("src/lib.rs").exists(), "Library should have lib.rs");
-    assert!(!project_dir.join("src/main.rs").exists(), "Library should not have main.rs");
-    assert!(project_dir.join("examples").exists(), "Library should have examples directory");
-    assert!(project_dir.join("examples/basic.rs").exists(), "Library should have basic example");
-    
+    assert!(
+        project_dir.join("src/lib.rs").exists(),
+        "Library should have lib.rs"
+    );
+    assert!(
+        !project_dir.join("src/main.rs").exists(),
+        "Library should not have main.rs"
+    );
+    assert!(
+        project_dir.join("examples").exists(),
+        "Library should have examples directory"
+    );
+    assert!(
+        project_dir.join("examples/basic.rs").exists(),
+        "Library should have basic example"
+    );
+
     // Verify lib.rs contains documentation comment
     verify_file_contains(
         &project_dir.join("src/lib.rs"),
         &["//! Test library project"],
-    ).expect("lib.rs verification failed");
-    
+    )
+    .expect("lib.rs verification failed");
+
     // Verify Cargo.toml contains correct library configuration
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -253,14 +273,13 @@ fn test_library_integration() {
             "[lib]",
             "test_library", // Note: hyphens converted to underscores
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify .gitignore includes Cargo.lock for libraries
-    verify_file_contains(
-        &project_dir.join(".gitignore"),
-        &["/target", "Cargo.lock"],
-    ).expect(".gitignore verification failed");
-    
+    verify_file_contains(&project_dir.join(".gitignore"), &["/target", "Cargo.lock"])
+        .expect(".gitignore verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -272,8 +291,9 @@ fn test_library_integration() {
             "[dependencies]",
             "test-library = \"0.1.0\"",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the project compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("Library project compiles successfully"),
@@ -286,17 +306,17 @@ fn test_wasm_app_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-wasm-app");
     let config = create_test_config("test-wasm-app", "wasm-app");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate WASM app project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify WASM app specific files
     let wasm_files = vec![
         "src/lib.rs",
@@ -306,16 +326,23 @@ fn test_wasm_app_integration() {
         "webpack.config.js",
         "build.sh",
     ];
-    
+
     for file in wasm_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "WASM app file '{}' does not exist", file);
+        assert!(
+            file_path.exists(),
+            "WASM app file '{}' does not exist",
+            file
+        );
         assert!(file_path.is_file(), "'{}' is not a file", file);
     }
-    
+
     // Verify no main.rs exists (WASM uses lib.rs)
-    assert!(!project_dir.join("src/main.rs").exists(), "WASM app should not have main.rs");
-    
+    assert!(
+        !project_dir.join("src/main.rs").exists(),
+        "WASM app should not have main.rs"
+    );
+
     // Verify Cargo.toml contains correct dependencies and library configuration
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -329,14 +356,16 @@ fn test_wasm_app_integration() {
             "[lib]",
             r#"crate-type = ["cdylib"]"#,
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify .gitignore includes WASM-specific entries
     verify_file_contains(
         &project_dir.join(".gitignore"),
         &["/target", "node_modules", "dist/", "pkg/"],
-    ).expect(".gitignore verification failed");
-    
+    )
+    .expect(".gitignore verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -349,8 +378,9 @@ fn test_wasm_app_integration() {
             "npm start",
             "http://localhost:8080",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the project compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("WASM app project compiles successfully"),
@@ -362,11 +392,11 @@ fn test_wasm_app_integration() {
 fn test_template_variable_substitution_all_types() {
     let temp_dir = create_test_dir();
     let project_types = vec!["api-server", "cli-tool", "library", "wasm-app"];
-    
+
     for project_type in project_types {
         let project_name = format!("subst-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
-        
+
         let config = ProjectConfig {
             name: project_name.clone(),
             project_type: project_type.to_string(),
@@ -374,11 +404,12 @@ fn test_template_variable_substitution_all_types() {
             description: Some(format!("Custom description for {}", project_type)),
             features: vec![],
         };
-        
+
         let generator = Generator::new();
-        generator.generate(&config, &project_dir)
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Verify all substitutions in Cargo.toml
         verify_file_contains(
             &project_dir.join("Cargo.toml"),
@@ -389,8 +420,12 @@ fn test_template_variable_substitution_all_types() {
                 "version = \"0.1.0\"",
                 "edition = \"2021\"",
             ],
-        ).expect(&format!("Variable substitution failed for {} Cargo.toml", project_type));
-        
+        )
+        .expect(&format!(
+            "Variable substitution failed for {} Cargo.toml",
+            project_type
+        ));
+
         // Verify substitutions in README.md
         verify_file_contains(
             &project_dir.join("README.md"),
@@ -398,7 +433,11 @@ fn test_template_variable_substitution_all_types() {
                 &format!("# {}", project_name),
                 &format!("Custom description for {}", project_type),
             ],
-        ).expect(&format!("Variable substitution failed for {} README.md", project_type));
+        )
+        .expect(&format!(
+            "Variable substitution failed for {} README.md",
+            project_type
+        ));
     }
 }
 
@@ -408,7 +447,7 @@ fn test_project_compilation_with_minimal_code() {
     // but also contain minimal compilable code
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     // Test each project type compiles
     let test_cases = vec![
         ("compile-api", "api-server"),
@@ -416,41 +455,49 @@ fn test_project_compilation_with_minimal_code() {
         ("compile-lib", "library"),
         ("compile-wasm", "wasm-app"),
     ];
-    
+
     for (name, project_type) in test_cases {
         let project_dir = temp_dir.path().join(name);
         let config = create_test_config(name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Ensure the project compiles without errors
         match run_cargo_check(&project_dir) {
             Ok(_) => {
                 println!("{} project '{}' compiles successfully", project_type, name);
-                
+
                 // Additional check: verify main entry point has some content
                 match project_type {
                     "api-server" | "cli-tool" => {
                         let main_content = fs::read_to_string(project_dir.join("src/main.rs"))
                             .expect("Failed to read main.rs");
-                        assert!(main_content.contains("fn main()"), 
-                            "main.rs should contain main function");
-                    },
+                        assert!(
+                            main_content.contains("fn main()"),
+                            "main.rs should contain main function"
+                        );
+                    }
                     "library" => {
                         let lib_content = fs::read_to_string(project_dir.join("src/lib.rs"))
                             .expect("Failed to read lib.rs");
-                        assert!(lib_content.contains("//!"), 
-                            "lib.rs should contain documentation comment");
-                    },
+                        assert!(
+                            lib_content.contains("//!"),
+                            "lib.rs should contain documentation comment"
+                        );
+                    }
                     "wasm-app" => {
                         // WASM app has empty lib.rs by default, which is fine
                         assert!(project_dir.join("src/lib.rs").exists());
-                    },
+                    }
                     _ => {}
                 }
-            },
-            Err(e) => panic!("{} project '{}' compilation failed: {}", project_type, name, e),
+            }
+            Err(e) => panic!(
+                "{} project '{}' compilation failed: {}",
+                project_type, name, e
+            ),
         }
     }
 }
@@ -460,7 +507,7 @@ fn test_project_name_sanitization() {
     // Test that project names with special characters are handled correctly
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("special-name-test");
-    
+
     let config = ProjectConfig {
         name: "my-special_project.123".to_string(),
         project_type: "library".to_string(),
@@ -468,19 +515,22 @@ fn test_project_name_sanitization() {
         description: Some("Project with special name".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate project with special name");
-    
+
     // Verify the library name in Cargo.toml is properly sanitized
-    let cargo_content = fs::read_to_string(project_dir.join("Cargo.toml"))
-        .expect("Failed to read Cargo.toml");
-    
+    let cargo_content =
+        fs::read_to_string(project_dir.join("Cargo.toml")).expect("Failed to read Cargo.toml");
+
     // Library names should have hyphens converted to underscores
-    assert!(cargo_content.contains("name = \"my_special_project_123\"") || 
-            cargo_content.contains("name = \"my-special_project.123\""),
-            "Library name should be in Cargo.toml");
+    assert!(
+        cargo_content.contains("name = \"my_special_project_123\"")
+            || cargo_content.contains("name = \"my-special_project.123\""),
+        "Library name should be in Cargo.toml"
+    );
 }
 
 #[test]
@@ -488,50 +538,104 @@ fn test_directory_structure_completeness() {
     // Comprehensive test to ensure all expected directories and files are created
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     // Define expected structure for each project type
     let project_structures = vec![
-        ("api-server", vec![
-            "src/", "src/main.rs", "src/routes.rs", "src/handlers.rs", "src/models.rs",
-            "tests/", "config/", "config/default.toml", ".env.example",
-            "Cargo.toml", "README.md", ".gitignore"
-        ]),
-        ("cli-tool", vec![
-            "src/", "src/main.rs", "src/cli.rs", "src/commands.rs",
-            "tests/", "Cargo.toml", "README.md", ".gitignore"
-        ]),
-        ("library", vec![
-            "src/", "src/lib.rs", "tests/", "examples/", "examples/basic.rs",
-            "Cargo.toml", "README.md", ".gitignore"
-        ]),
-        ("wasm-app", vec![
-            "src/", "src/lib.rs", "tests/", "index.html", "index.js",
-            "package.json", "webpack.config.js", "build.sh",
-            "Cargo.toml", "README.md", ".gitignore"
-        ]),
+        (
+            "api-server",
+            vec![
+                "src/",
+                "src/main.rs",
+                "src/routes.rs",
+                "src/handlers.rs",
+                "src/models.rs",
+                "tests/",
+                "config/",
+                "config/default.toml",
+                ".env.example",
+                "Cargo.toml",
+                "README.md",
+                ".gitignore",
+            ],
+        ),
+        (
+            "cli-tool",
+            vec![
+                "src/",
+                "src/main.rs",
+                "src/cli.rs",
+                "src/commands.rs",
+                "tests/",
+                "Cargo.toml",
+                "README.md",
+                ".gitignore",
+            ],
+        ),
+        (
+            "library",
+            vec![
+                "src/",
+                "src/lib.rs",
+                "tests/",
+                "examples/",
+                "examples/basic.rs",
+                "Cargo.toml",
+                "README.md",
+                ".gitignore",
+            ],
+        ),
+        (
+            "wasm-app",
+            vec![
+                "src/",
+                "src/lib.rs",
+                "tests/",
+                "index.html",
+                "index.js",
+                "package.json",
+                "webpack.config.js",
+                "build.sh",
+                "Cargo.toml",
+                "README.md",
+                ".gitignore",
+            ],
+        ),
     ];
-    
+
     for (project_type, expected_paths) in project_structures {
         let project_name = format!("structure-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Check each expected path
         for path in expected_paths {
             let full_path = project_dir.join(path);
-            assert!(full_path.exists(), 
-                "{} project should have '{}'", project_type, path);
-            
+            assert!(
+                full_path.exists(),
+                "{} project should have '{}'",
+                project_type,
+                path
+            );
+
             // Verify it's the correct type (file vs directory)
             if path.ends_with('/') {
-                assert!(full_path.is_dir(), 
-                    "'{}' should be a directory in {} project", path, project_type);
+                assert!(
+                    full_path.is_dir(),
+                    "'{}' should be a directory in {} project",
+                    path,
+                    project_type
+                );
             } else {
-                assert!(full_path.is_file(), 
-                    "'{}' should be a file in {} project", path, project_type);
+                assert!(
+                    full_path.is_file(),
+                    "'{}' should be a file in {} project",
+                    path,
+                    project_type
+                );
             }
         }
     }
@@ -542,17 +646,17 @@ fn test_game_engine_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-game-engine");
     let config = create_test_config("test-game-engine", "game-engine");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate game engine project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify game engine specific files
     let game_files = vec![
         "src/main.rs",
@@ -564,21 +668,28 @@ fn test_game_engine_integration() {
         "assets/shaders/",
         ".github/workflows/wasm.yml",
     ];
-    
+
     for file in game_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "Game engine file '{}' does not exist", file);
-        
+        assert!(
+            file_path.exists(),
+            "Game engine file '{}' does not exist",
+            file
+        );
+
         if file.ends_with('/') {
             assert!(file_path.is_dir(), "'{}' should be a directory", file);
         } else {
             assert!(file_path.is_file(), "'{}' should be a file", file);
         }
     }
-    
+
     // Verify no lib.rs exists (should be binary only)
-    assert!(!project_dir.join("src/lib.rs").exists(), "Game engine should not have lib.rs");
-    
+    assert!(
+        !project_dir.join("src/lib.rs").exists(),
+        "Game engine should not have lib.rs"
+    );
+
     // Verify Cargo.toml contains correct dependencies
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -593,14 +704,16 @@ fn test_game_engine_integration() {
             "[profile.dev]",
             "opt-level = 1",
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify .gitignore includes game-specific entries
     verify_file_contains(
         &project_dir.join(".gitignore"),
         &["/target", "wasm/", "*.wasm", ".DS_Store"],
-    ).expect(".gitignore verification failed");
-    
+    )
+    .expect(".gitignore verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -613,8 +726,9 @@ fn test_game_engine_integration() {
             "wasm32-unknown-unknown",
             "ESC: Exit game",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the project compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("Game engine project compiles successfully"),
@@ -627,17 +741,17 @@ fn test_embedded_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-embedded");
     let config = create_test_config("test-embedded", "embedded");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate embedded project");
-    
+
     // Verify common files
-    verify_common_files(&project_dir)
-        .expect("Common files verification failed");
-    
+    verify_common_files(&project_dir).expect("Common files verification failed");
+
     // Verify embedded specific files
     let embedded_files = vec![
         "src/main.rs",
@@ -646,27 +760,35 @@ fn test_embedded_integration() {
         "memory.x",
         "Embed.toml",
     ];
-    
+
     for file in embedded_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "Embedded file '{}' does not exist", file);
-        
+        assert!(
+            file_path.exists(),
+            "Embedded file '{}' does not exist",
+            file
+        );
+
         if file.ends_with('/') {
             assert!(file_path.is_dir(), "'{}' should be a directory", file);
         } else {
             assert!(file_path.is_file(), "'{}' should be a file", file);
         }
     }
-    
+
     // Verify no lib.rs exists (should be binary only)
-    assert!(!project_dir.join("src/lib.rs").exists(), "Embedded should not have lib.rs");
-    
+    assert!(
+        !project_dir.join("src/lib.rs").exists(),
+        "Embedded should not have lib.rs"
+    );
+
     // Verify main.rs contains no_std attributes
     verify_file_contains(
         &project_dir.join("src/main.rs"),
         &["#![no_std]", "#![no_main]"],
-    ).expect("main.rs verification failed");
-    
+    )
+    .expect("main.rs verification failed");
+
     // Verify Cargo.toml contains correct dependencies
     verify_file_contains(
         &project_dir.join("Cargo.toml"),
@@ -682,14 +804,16 @@ fn test_embedded_integration() {
             "[profile.release]",
             "lto = \"fat\"",
         ],
-    ).expect("Cargo.toml verification failed");
-    
+    )
+    .expect("Cargo.toml verification failed");
+
     // Verify .gitignore includes embedded-specific entries
     verify_file_contains(
         &project_dir.join(".gitignore"),
         &["/target", "*.bin", "*.hex", "*.elf", ".vscode/"],
-    ).expect(".gitignore verification failed");
-    
+    )
+    .expect(".gitignore verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -703,8 +827,9 @@ fn test_embedded_integration() {
             "probe-rs",
             "RTT logging",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Skip cargo check for embedded projects as they require specific targets
     // that may not be available in all test environments
     println!("✓ Embedded project structure and content validation completed");
@@ -716,13 +841,14 @@ fn test_workspace_integration() {
     let temp_dir = create_test_dir();
     let project_dir = temp_dir.path().join("test-workspace");
     let config = create_test_config("test-workspace", "workspace");
-    
+
     let generator = Generator::new();
-    
+
     // Generate the project
-    generator.generate(&config, &project_dir)
+    generator
+        .generate(&config, &project_dir)
         .expect("Failed to generate workspace project");
-    
+
     // Verify workspace specific structure
     let workspace_files = vec![
         "Cargo.toml",
@@ -742,45 +868,50 @@ fn test_workspace_integration() {
         "crates/cli/src/main.rs",
         "crates/cli/Cargo.toml",
     ];
-    
+
     for file in workspace_files {
         let file_path = project_dir.join(file);
-        assert!(file_path.exists(), "Workspace file '{}' does not exist", file);
-        
+        assert!(
+            file_path.exists(),
+            "Workspace file '{}' does not exist",
+            file
+        );
+
         if file.ends_with('/') {
             assert!(file_path.is_dir(), "'{}' should be a directory", file);
         } else {
             assert!(file_path.is_file(), "'{}' should be a file", file);
         }
     }
-    
+
     // Verify no src/ directory at root (workspace doesn't have root src)
-    assert!(!project_dir.join("src/").exists(), "Workspace should not have root src directory");
-    
+    assert!(
+        !project_dir.join("src/").exists(),
+        "Workspace should not have root src directory"
+    );
+
     // Verify core crate lib.rs contains documentation
     verify_file_contains(
         &project_dir.join("crates/core/src/lib.rs"),
         &["//! Core library"],
-    ).expect("Core lib.rs verification failed");
-    
+    )
+    .expect("Core lib.rs verification failed");
+
     // Verify API crate lib.rs contains documentation
     verify_file_contains(
         &project_dir.join("crates/api/src/lib.rs"),
         &["//! API library"],
-    ).expect("API lib.rs verification failed");
-    
+    )
+    .expect("API lib.rs verification failed");
+
     // Verify CLI crate main.rs contains main function
-    verify_file_contains(
-        &project_dir.join("crates/cli/src/main.rs"),
-        &["fn main()"],
-    ).expect("CLI main.rs verification failed");
-    
+    verify_file_contains(&project_dir.join("crates/cli/src/main.rs"), &["fn main()"])
+        .expect("CLI main.rs verification failed");
+
     // Verify .gitignore includes workspace-specific entries
-    verify_file_contains(
-        &project_dir.join(".gitignore"),
-        &["/target", "Cargo.lock"],
-    ).expect(".gitignore verification failed");
-    
+    verify_file_contains(&project_dir.join(".gitignore"), &["/target", "Cargo.lock"])
+        .expect(".gitignore verification failed");
+
     // Verify README contains project-specific content
     verify_file_contains(
         &project_dir.join("README.md"),
@@ -795,8 +926,9 @@ fn test_workspace_integration() {
             "cargo build",
             "cargo run",
         ],
-    ).expect("README.md verification failed");
-    
+    )
+    .expect("README.md verification failed");
+
     // Run cargo check to verify the workspace compiles
     match run_cargo_check(&project_dir) {
         Ok(_) => println!("Workspace project compiles successfully"),
@@ -809,25 +941,26 @@ fn test_all_project_types_compilation() {
     // This test ensures that ALL project types compile successfully
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    
+
     let project_types = vec![
         "api-server",
-        "cli-tool", 
+        "cli-tool",
         "library",
         "wasm-app",
         "game-engine",
         "embedded",
         "workspace",
     ];
-    
+
     for project_type in project_types {
         let project_name = format!("compile-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Ensure the project compiles without errors (skip embedded as it requires special targets)
         if project_type != "embedded" {
             match run_cargo_check(&project_dir) {
@@ -835,7 +968,10 @@ fn test_all_project_types_compilation() {
                 Err(e) => panic!("✗ {} project compilation failed: {}", project_type, e),
             }
         } else {
-            println!("✓ {} project structure validated (compilation skipped)", project_type);
+            println!(
+                "✓ {} project structure validated (compilation skipped)",
+                project_type
+            );
         }
     }
 }
@@ -845,29 +981,38 @@ fn test_cross_platform_file_generation() {
     // Test that file generation works consistently across platforms
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    let project_types = vec!["api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"];
-    
+    let project_types = vec![
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
+    ];
+
     for project_type in project_types {
         let project_name = format!("cross-platform-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
-        generator.generate(&config, &project_dir)
+
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
-        
+
         // Verify common files exist and are readable
         let common_files = vec!["Cargo.toml", "README.md", ".gitignore"];
         for file in common_files {
             let file_path = project_dir.join(file);
             assert!(file_path.exists(), "{} should have {}", project_type, file);
             assert!(file_path.is_file(), "{} should be a file", file);
-            
+
             // Verify file is readable
-            let content = fs::read_to_string(&file_path)
-                .expect(&format!("Should be able to read {}", file));
+            let content =
+                fs::read_to_string(&file_path).expect(&format!("Should be able to read {}", file));
             assert!(!content.is_empty(), "{} should not be empty", file);
         }
-        
+
         println!("✓ {} project generates files correctly", project_type);
     }
 }
@@ -877,22 +1022,35 @@ fn test_project_generation_performance() {
     // Test that project generation is reasonably fast
     let temp_dir = create_test_dir();
     let generator = Generator::new();
-    let project_types = vec!["api-server", "cli-tool", "library", "wasm-app", "game-engine", "embedded", "workspace"];
-    
+    let project_types = vec![
+        "api-server",
+        "cli-tool",
+        "library",
+        "wasm-app",
+        "game-engine",
+        "embedded",
+        "workspace",
+    ];
+
     for project_type in project_types {
         let project_name = format!("perf-test-{}", project_type);
         let project_dir = temp_dir.path().join(&project_name);
         let config = create_test_config(&project_name, project_type);
-        
+
         let start = std::time::Instant::now();
-        generator.generate(&config, &project_dir)
+        generator
+            .generate(&config, &project_dir)
             .expect(&format!("Failed to generate {} project", project_type));
         let duration = start.elapsed();
-        
+
         // Project generation should complete within reasonable time
-        assert!(duration.as_secs() < 5, 
-            "{} project generation took too long: {:?}", project_type, duration);
-        
+        assert!(
+            duration.as_secs() < 5,
+            "{} project generation took too long: {:?}",
+            project_type,
+            duration
+        );
+
         println!("✓ {} project generated in {:?}", project_type, duration);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,6 +11,8 @@ fn create_test_config(name: &str, project_type: &str) -> ProjectConfig {
         project_type: project_type.to_string(),
         author: "Test Author <test@example.com>".to_string(),
         description: Some(format!("Test {} project", project_type)),
+        esp32_chip: None,
+        target: None,
         features: vec![],
     }
 }
@@ -402,6 +404,8 @@ fn test_template_variable_substitution_all_types() {
             project_type: project_type.to_string(),
             author: "Jane Smith <jane@example.com>".to_string(),
             description: Some(format!("Custom description for {}", project_type)),
+            esp32_chip: None,
+            target: None,
             features: vec![],
         };
 
@@ -513,6 +517,8 @@ fn test_project_name_sanitization() {
         project_type: "library".to_string(),
         author: "Test Author".to_string(),
         description: Some("Project with special name".to_string()),
+        esp32_chip: None,
+        target: None,
         features: vec![],
     };
 

--- a/tests/project_types_test.rs
+++ b/tests/project_types_test.rs
@@ -15,6 +15,8 @@ fn test_api_server_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test API Server".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -80,6 +82,8 @@ fn test_cli_tool_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test CLI Tool".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -137,6 +141,8 @@ fn test_library_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test Library".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -194,6 +200,8 @@ fn test_wasm_app_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test WASM App".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -290,6 +298,8 @@ fn test_project_type_specific_readme() {
             author: "Test Author".to_string(),
             description: Some(format!("Test {}", type_name)),
             features: vec![],
+            target: None,
+            esp32_chip: None
         };
 
         let generator = Generator::new();
@@ -322,6 +332,8 @@ fn test_project_type_specific_gitignore() {
         author: "Test Author".to_string(),
         description: None,
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -354,6 +366,8 @@ fn test_game_engine_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test Game Engine".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -415,6 +429,8 @@ fn test_embedded_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test Embedded System".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();
@@ -473,6 +489,8 @@ fn test_workspace_project_type() {
         author: "Test Author".to_string(),
         description: Some("Test Workspace".to_string()),
         features: vec![],
+        target: None,
+        esp32_chip: None
     };
 
     let generator = Generator::new();

--- a/tests/project_types_test.rs
+++ b/tests/project_types_test.rs
@@ -1,4 +1,4 @@
-use cargo_forge::{ProjectType, Generator, ProjectConfig};
+use cargo_forge::{Generator, ProjectConfig, ProjectType};
 use std::fs;
 use std::str::FromStr;
 use tempfile::TempDir;
@@ -8,7 +8,7 @@ fn test_api_server_project_type() {
     // This test should fail as the implementation doesn't exist yet
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("api-server-test");
-    
+
     let config = ProjectConfig {
         name: "api-server-test".to_string(),
         project_type: ProjectType::ApiServer.to_string(),
@@ -16,26 +16,56 @@ fn test_api_server_project_type() {
         description: Some("Test API Server".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check API server specific files and dependencies
-    assert!(output_dir.join("src/main.rs").exists(), "API server should have main.rs");
-    assert!(output_dir.join("src/routes.rs").exists(), "API server should have routes module");
-    assert!(output_dir.join("src/handlers.rs").exists(), "API server should have handlers module");
-    assert!(output_dir.join("src/models.rs").exists(), "API server should have models module");
-    
+    assert!(
+        output_dir.join("src/main.rs").exists(),
+        "API server should have main.rs"
+    );
+    assert!(
+        output_dir.join("src/routes.rs").exists(),
+        "API server should have routes module"
+    );
+    assert!(
+        output_dir.join("src/handlers.rs").exists(),
+        "API server should have handlers module"
+    );
+    assert!(
+        output_dir.join("src/models.rs").exists(),
+        "API server should have models module"
+    );
+
     // Check Cargo.toml for API server dependencies
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("axum"), "API server should have axum dependency");
-    assert!(cargo_content.contains("tokio"), "API server should have tokio dependency");
-    assert!(cargo_content.contains("serde"), "API server should have serde dependency");
-    assert!(cargo_content.contains("tower"), "API server should have tower dependency");
-    
+    assert!(
+        cargo_content.contains("axum"),
+        "API server should have axum dependency"
+    );
+    assert!(
+        cargo_content.contains("tokio"),
+        "API server should have tokio dependency"
+    );
+    assert!(
+        cargo_content.contains("serde"),
+        "API server should have serde dependency"
+    );
+    assert!(
+        cargo_content.contains("tower"),
+        "API server should have tower dependency"
+    );
+
     // Check for config files
-    assert!(output_dir.join(".env.example").exists(), "API server should have .env.example");
-    assert!(output_dir.join("config/default.toml").exists(), "API server should have config file");
+    assert!(
+        output_dir.join(".env.example").exists(),
+        "API server should have .env.example"
+    );
+    assert!(
+        output_dir.join("config/default.toml").exists(),
+        "API server should have config file"
+    );
 }
 
 #[test]
@@ -43,7 +73,7 @@ fn test_cli_tool_project_type() {
     // Test CLI tool project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("cli-tool-test");
-    
+
     let config = ProjectConfig {
         name: "cli-tool-test".to_string(),
         project_type: ProjectType::CliTool.to_string(),
@@ -51,24 +81,48 @@ fn test_cli_tool_project_type() {
         description: Some("Test CLI Tool".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check CLI tool specific files
-    assert!(output_dir.join("src/main.rs").exists(), "CLI tool should have main.rs");
-    assert!(output_dir.join("src/cli.rs").exists(), "CLI tool should have cli module");
-    assert!(output_dir.join("src/commands.rs").exists(), "CLI tool should have commands module");
-    
+    assert!(
+        output_dir.join("src/main.rs").exists(),
+        "CLI tool should have main.rs"
+    );
+    assert!(
+        output_dir.join("src/cli.rs").exists(),
+        "CLI tool should have cli module"
+    );
+    assert!(
+        output_dir.join("src/commands.rs").exists(),
+        "CLI tool should have commands module"
+    );
+
     // Check Cargo.toml for CLI dependencies
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("clap"), "CLI tool should have clap dependency");
-    assert!(cargo_content.contains("anyhow"), "CLI tool should have anyhow dependency");
-    assert!(cargo_content.contains("env_logger"), "CLI tool should have env_logger dependency");
-    
+    assert!(
+        cargo_content.contains("clap"),
+        "CLI tool should have clap dependency"
+    );
+    assert!(
+        cargo_content.contains("anyhow"),
+        "CLI tool should have anyhow dependency"
+    );
+    assert!(
+        cargo_content.contains("env_logger"),
+        "CLI tool should have env_logger dependency"
+    );
+
     // Check for CLI-specific features in Cargo.toml
-    assert!(cargo_content.contains("[[bin]]"), "CLI tool should have binary target");
-    assert!(cargo_content.contains(r#"name = "cli-tool-test""#), "Binary name should match project");
+    assert!(
+        cargo_content.contains("[[bin]]"),
+        "CLI tool should have binary target"
+    );
+    assert!(
+        cargo_content.contains(r#"name = "cli-tool-test""#),
+        "Binary name should match project"
+    );
 }
 
 #[test]
@@ -76,7 +130,7 @@ fn test_library_project_type() {
     // Test library project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("library-test");
-    
+
     let config = ProjectConfig {
         name: "library-test".to_string(),
         project_type: ProjectType::Library.to_string(),
@@ -84,27 +138,48 @@ fn test_library_project_type() {
         description: Some("Test Library".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check library specific files
-    assert!(output_dir.join("src/lib.rs").exists(), "Library should have lib.rs");
-    assert!(!output_dir.join("src/main.rs").exists(), "Library should not have main.rs");
-    
+    assert!(
+        output_dir.join("src/lib.rs").exists(),
+        "Library should have lib.rs"
+    );
+    assert!(
+        !output_dir.join("src/main.rs").exists(),
+        "Library should not have main.rs"
+    );
+
     // Check for examples directory
-    assert!(output_dir.join("examples").exists(), "Library should have examples directory");
-    assert!(output_dir.join("examples/basic.rs").exists(), "Library should have basic example");
-    
+    assert!(
+        output_dir.join("examples").exists(),
+        "Library should have examples directory"
+    );
+    assert!(
+        output_dir.join("examples/basic.rs").exists(),
+        "Library should have basic example"
+    );
+
     // Check Cargo.toml library configuration
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("[lib]"), "Library should have [lib] section");
-    assert!(cargo_content.contains(r#"name = "library_test""#), "Library name should be snake_case");
-    
+    assert!(
+        cargo_content.contains("[lib]"),
+        "Library should have [lib] section"
+    );
+    assert!(
+        cargo_content.contains(r#"name = "library_test""#),
+        "Library name should be snake_case"
+    );
+
     // Check for documentation
     assert!(output_dir.join("src/lib.rs").exists());
     let lib_content = fs::read_to_string(output_dir.join("src/lib.rs")).unwrap();
-    assert!(lib_content.contains("//!"), "Library should have crate-level documentation");
+    assert!(
+        lib_content.contains("//!"),
+        "Library should have crate-level documentation"
+    );
 }
 
 #[test]
@@ -112,7 +187,7 @@ fn test_wasm_app_project_type() {
     // Test WASM application project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("wasm-app-test");
-    
+
     let config = ProjectConfig {
         name: "wasm-app-test".to_string(),
         project_type: ProjectType::WasmApp.to_string(),
@@ -120,28 +195,60 @@ fn test_wasm_app_project_type() {
         description: Some("Test WASM App".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check WASM specific files
-    assert!(output_dir.join("src/lib.rs").exists(), "WASM app should have lib.rs");
-    assert!(output_dir.join("index.html").exists(), "WASM app should have index.html");
-    assert!(output_dir.join("index.js").exists(), "WASM app should have index.js");
-    assert!(output_dir.join("package.json").exists(), "WASM app should have package.json");
-    assert!(output_dir.join("webpack.config.js").exists(), "WASM app should have webpack config");
-    
+    assert!(
+        output_dir.join("src/lib.rs").exists(),
+        "WASM app should have lib.rs"
+    );
+    assert!(
+        output_dir.join("index.html").exists(),
+        "WASM app should have index.html"
+    );
+    assert!(
+        output_dir.join("index.js").exists(),
+        "WASM app should have index.js"
+    );
+    assert!(
+        output_dir.join("package.json").exists(),
+        "WASM app should have package.json"
+    );
+    assert!(
+        output_dir.join("webpack.config.js").exists(),
+        "WASM app should have webpack config"
+    );
+
     // Check Cargo.toml for WASM dependencies
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("wasm-bindgen"), "WASM app should have wasm-bindgen");
-    assert!(cargo_content.contains("web-sys"), "WASM app should have web-sys");
-    assert!(cargo_content.contains("js-sys"), "WASM app should have js-sys");
-    assert!(cargo_content.contains("[lib]"), "WASM app should have [lib] section");
-    assert!(cargo_content.contains(r#"crate-type = ["cdylib"]"#), "WASM app should be cdylib");
-    
+    assert!(
+        cargo_content.contains("wasm-bindgen"),
+        "WASM app should have wasm-bindgen"
+    );
+    assert!(
+        cargo_content.contains("web-sys"),
+        "WASM app should have web-sys"
+    );
+    assert!(
+        cargo_content.contains("js-sys"),
+        "WASM app should have js-sys"
+    );
+    assert!(
+        cargo_content.contains("[lib]"),
+        "WASM app should have [lib] section"
+    );
+    assert!(
+        cargo_content.contains(r#"crate-type = ["cdylib"]"#),
+        "WASM app should be cdylib"
+    );
+
     // Check for build script
-    assert!(output_dir.join("build.sh").exists() || output_dir.join("build.rs").exists(), 
-            "WASM app should have build script");
+    assert!(
+        output_dir.join("build.sh").exists() || output_dir.join("build.rs").exists(),
+        "WASM app should have build script"
+    );
 }
 
 #[test]
@@ -149,15 +256,34 @@ fn test_project_type_specific_readme() {
     // Test that each project type generates appropriate README content
     let temp_dir = TempDir::new().unwrap();
     let types = vec![
-        (ProjectType::ApiServer, "API Server", vec!["endpoint", "axum", "rest"]),
-        (ProjectType::CliTool, "CLI Tool", vec!["command", "usage", "help"]),
-        (ProjectType::Library, "Library", vec!["example", "cargo", "documentation"]),
-        (ProjectType::WasmApp, "WASM App", vec!["webpack", "install", "build"]),
+        (
+            ProjectType::ApiServer,
+            "API Server",
+            vec!["endpoint", "axum", "rest"],
+        ),
+        (
+            ProjectType::CliTool,
+            "CLI Tool",
+            vec!["command", "usage", "help"],
+        ),
+        (
+            ProjectType::Library,
+            "Library",
+            vec!["example", "cargo", "documentation"],
+        ),
+        (
+            ProjectType::WasmApp,
+            "WASM App",
+            vec!["webpack", "install", "build"],
+        ),
     ];
-    
+
     for (project_type, type_name, expected_words) in types {
-        let output_dir = temp_dir.path().join(format!("{}-readme-test", type_name.to_lowercase().replace(" ", "-")));
-        
+        let output_dir = temp_dir.path().join(format!(
+            "{}-readme-test",
+            type_name.to_lowercase().replace(" ", "-")
+        ));
+
         let config = ProjectConfig {
             name: format!("{}-test", type_name.to_lowercase().replace(" ", "-")),
             project_type: project_type.to_string(),
@@ -165,16 +291,20 @@ fn test_project_type_specific_readme() {
             description: Some(format!("Test {}", type_name)),
             features: vec![],
         };
-        
+
         let generator = Generator::new();
         generator.generate(&config, &output_dir).unwrap();
-        
+
         let readme_content = fs::read_to_string(output_dir.join("README.md")).unwrap();
-        
+
         // Check for type-specific content
         for word in expected_words {
-            assert!(readme_content.to_lowercase().contains(word), 
-                    "{} README should contain '{}'", type_name, word);
+            assert!(
+                readme_content.to_lowercase().contains(word),
+                "{} README should contain '{}'",
+                type_name,
+                word
+            );
         }
     }
 }
@@ -183,7 +313,7 @@ fn test_project_type_specific_readme() {
 fn test_project_type_specific_gitignore() {
     // Test that each project type has appropriate .gitignore entries
     let temp_dir = TempDir::new().unwrap();
-    
+
     // Test WASM app specific gitignore
     let wasm_dir = temp_dir.path().join("wasm-gitignore-test");
     let wasm_config = ProjectConfig {
@@ -193,14 +323,23 @@ fn test_project_type_specific_gitignore() {
         description: None,
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&wasm_config, &wasm_dir).unwrap();
-    
+
     let gitignore_content = fs::read_to_string(wasm_dir.join(".gitignore")).unwrap();
-    assert!(gitignore_content.contains("node_modules"), "WASM .gitignore should exclude node_modules");
-    assert!(gitignore_content.contains("dist/"), "WASM .gitignore should exclude dist/");
-    assert!(gitignore_content.contains("pkg/"), "WASM .gitignore should exclude pkg/");
+    assert!(
+        gitignore_content.contains("node_modules"),
+        "WASM .gitignore should exclude node_modules"
+    );
+    assert!(
+        gitignore_content.contains("dist/"),
+        "WASM .gitignore should exclude dist/"
+    );
+    assert!(
+        gitignore_content.contains("pkg/"),
+        "WASM .gitignore should exclude pkg/"
+    );
 }
 
 #[test]
@@ -208,7 +347,7 @@ fn test_game_engine_project_type() {
     // Test game engine project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("game-engine-test");
-    
+
     let config = ProjectConfig {
         name: "game-engine-test".to_string(),
         project_type: ProjectType::GameEngine.to_string(),
@@ -216,25 +355,52 @@ fn test_game_engine_project_type() {
         description: Some("Test Game Engine".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check game engine specific files
-    assert!(output_dir.join("src/main.rs").exists(), "Game engine should have main.rs");
-    assert!(output_dir.join("assets").exists(), "Game engine should have assets directory");
-    assert!(output_dir.join("assets/models").exists(), "Game engine should have models directory");
-    assert!(output_dir.join("assets/textures").exists(), "Game engine should have textures directory");
-    assert!(output_dir.join("assets/sounds").exists(), "Game engine should have sounds directory");
-    assert!(output_dir.join("assets/shaders").exists(), "Game engine should have shaders directory");
-    
+    assert!(
+        output_dir.join("src/main.rs").exists(),
+        "Game engine should have main.rs"
+    );
+    assert!(
+        output_dir.join("assets").exists(),
+        "Game engine should have assets directory"
+    );
+    assert!(
+        output_dir.join("assets/models").exists(),
+        "Game engine should have models directory"
+    );
+    assert!(
+        output_dir.join("assets/textures").exists(),
+        "Game engine should have textures directory"
+    );
+    assert!(
+        output_dir.join("assets/sounds").exists(),
+        "Game engine should have sounds directory"
+    );
+    assert!(
+        output_dir.join("assets/shaders").exists(),
+        "Game engine should have shaders directory"
+    );
+
     // Check Cargo.toml for game engine dependencies
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("bevy"), "Game engine should have bevy dependency");
-    assert!(cargo_content.contains("[profile.dev]"), "Game engine should have dev profile optimization");
-    
+    assert!(
+        cargo_content.contains("bevy"),
+        "Game engine should have bevy dependency"
+    );
+    assert!(
+        cargo_content.contains("[profile.dev]"),
+        "Game engine should have dev profile optimization"
+    );
+
     // Check for WASM target support
-    assert!(cargo_content.contains("wasm-bindgen"), "Game engine should support WASM target");
+    assert!(
+        cargo_content.contains("wasm-bindgen"),
+        "Game engine should support WASM target"
+    );
 }
 
 #[test]
@@ -242,7 +408,7 @@ fn test_embedded_project_type() {
     // Test embedded project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("embedded-test");
-    
+
     let config = ProjectConfig {
         name: "embedded-test".to_string(),
         project_type: ProjectType::Embedded.to_string(),
@@ -250,25 +416,49 @@ fn test_embedded_project_type() {
         description: Some("Test Embedded System".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check embedded specific files
-    assert!(output_dir.join("src/main.rs").exists(), "Embedded should have main.rs");
-    assert!(output_dir.join("memory.x").exists(), "Embedded should have memory.x linker script");
-    assert!(output_dir.join("Embed.toml").exists(), "Embedded should have Embed.toml config");
-    
+    assert!(
+        output_dir.join("src/main.rs").exists(),
+        "Embedded should have main.rs"
+    );
+    assert!(
+        output_dir.join("memory.x").exists(),
+        "Embedded should have memory.x linker script"
+    );
+    assert!(
+        output_dir.join("Embed.toml").exists(),
+        "Embedded should have Embed.toml config"
+    );
+
     // Check Cargo.toml for embedded dependencies
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("cortex-m"), "Embedded should have cortex-m dependency");
-    assert!(cargo_content.contains("cortex-m-rt"), "Embedded should have cortex-m-rt dependency");
-    assert!(cargo_content.contains("panic-halt"), "Embedded should have panic-halt dependency");
-    
+    assert!(
+        cargo_content.contains("cortex-m"),
+        "Embedded should have cortex-m dependency"
+    );
+    assert!(
+        cargo_content.contains("cortex-m-rt"),
+        "Embedded should have cortex-m-rt dependency"
+    );
+    assert!(
+        cargo_content.contains("panic-halt"),
+        "Embedded should have panic-halt dependency"
+    );
+
     // Check for embedded-specific main.rs attributes
     let main_content = fs::read_to_string(output_dir.join("src/main.rs")).unwrap();
-    assert!(main_content.contains("#![no_std]"), "Embedded main.rs should have no_std");
-    assert!(main_content.contains("#![no_main]"), "Embedded main.rs should have no_main");
+    assert!(
+        main_content.contains("#![no_std]"),
+        "Embedded main.rs should have no_std"
+    );
+    assert!(
+        main_content.contains("#![no_main]"),
+        "Embedded main.rs should have no_main"
+    );
 }
 
 #[test]
@@ -276,7 +466,7 @@ fn test_workspace_project_type() {
     // Test workspace project generation
     let temp_dir = TempDir::new().unwrap();
     let output_dir = temp_dir.path().join("workspace-test");
-    
+
     let config = ProjectConfig {
         name: "workspace-test".to_string(),
         project_type: ProjectType::Workspace.to_string(),
@@ -284,30 +474,72 @@ fn test_workspace_project_type() {
         description: Some("Test Workspace".to_string()),
         features: vec![],
     };
-    
+
     let generator = Generator::new();
     generator.generate(&config, &output_dir).unwrap();
-    
+
     // Check workspace structure
-    assert!(output_dir.join("Cargo.toml").exists(), "Workspace should have root Cargo.toml");
-    assert!(output_dir.join("crates").exists(), "Workspace should have crates directory");
-    assert!(output_dir.join("crates/core").exists(), "Workspace should have core crate");
-    assert!(output_dir.join("crates/api").exists(), "Workspace should have api crate");
-    assert!(output_dir.join("crates/cli").exists(), "Workspace should have cli crate");
-    
+    assert!(
+        output_dir.join("Cargo.toml").exists(),
+        "Workspace should have root Cargo.toml"
+    );
+    assert!(
+        output_dir.join("crates").exists(),
+        "Workspace should have crates directory"
+    );
+    assert!(
+        output_dir.join("crates/core").exists(),
+        "Workspace should have core crate"
+    );
+    assert!(
+        output_dir.join("crates/api").exists(),
+        "Workspace should have api crate"
+    );
+    assert!(
+        output_dir.join("crates/cli").exists(),
+        "Workspace should have cli crate"
+    );
+
     // Check workspace Cargo.toml
     let cargo_content = fs::read_to_string(output_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("[workspace]"), "Should have workspace section");
-    assert!(cargo_content.contains("members ="), "Should have members list");
-    assert!(cargo_content.contains("crates/core"), "Should list core crate");
-    assert!(cargo_content.contains("crates/api"), "Should list api crate");
-    assert!(cargo_content.contains("crates/cli"), "Should list cli crate");
-    assert!(cargo_content.contains("[workspace.dependencies]"), "Should have workspace dependencies");
-    
+    assert!(
+        cargo_content.contains("[workspace]"),
+        "Should have workspace section"
+    );
+    assert!(
+        cargo_content.contains("members ="),
+        "Should have members list"
+    );
+    assert!(
+        cargo_content.contains("crates/core"),
+        "Should list core crate"
+    );
+    assert!(
+        cargo_content.contains("crates/api"),
+        "Should list api crate"
+    );
+    assert!(
+        cargo_content.contains("crates/cli"),
+        "Should list cli crate"
+    );
+    assert!(
+        cargo_content.contains("[workspace.dependencies]"),
+        "Should have workspace dependencies"
+    );
+
     // Check individual crate files exist
-    assert!(output_dir.join("crates/core/src/lib.rs").exists(), "Core crate should have lib.rs");
-    assert!(output_dir.join("crates/api/src/lib.rs").exists(), "API crate should have lib.rs");
-    assert!(output_dir.join("crates/cli/src/main.rs").exists(), "CLI crate should have main.rs");
+    assert!(
+        output_dir.join("crates/core/src/lib.rs").exists(),
+        "Core crate should have lib.rs"
+    );
+    assert!(
+        output_dir.join("crates/api/src/lib.rs").exists(),
+        "API crate should have lib.rs"
+    );
+    assert!(
+        output_dir.join("crates/cli/src/main.rs").exists(),
+        "CLI crate should have main.rs"
+    );
 }
 
 #[test]
@@ -325,14 +557,35 @@ fn test_project_type_enum_display() {
 #[test]
 fn test_project_type_from_string() {
     // Test parsing ProjectType from string
-    assert_eq!(ProjectType::from_str("api-server").unwrap(), ProjectType::ApiServer);
-    assert_eq!(ProjectType::from_str("cli-tool").unwrap(), ProjectType::CliTool);
-    assert_eq!(ProjectType::from_str("library").unwrap(), ProjectType::Library);
-    assert_eq!(ProjectType::from_str("wasm-app").unwrap(), ProjectType::WasmApp);
-    assert_eq!(ProjectType::from_str("game-engine").unwrap(), ProjectType::GameEngine);
-    assert_eq!(ProjectType::from_str("embedded").unwrap(), ProjectType::Embedded);
-    assert_eq!(ProjectType::from_str("workspace").unwrap(), ProjectType::Workspace);
-    
+    assert_eq!(
+        ProjectType::from_str("api-server").unwrap(),
+        ProjectType::ApiServer
+    );
+    assert_eq!(
+        ProjectType::from_str("cli-tool").unwrap(),
+        ProjectType::CliTool
+    );
+    assert_eq!(
+        ProjectType::from_str("library").unwrap(),
+        ProjectType::Library
+    );
+    assert_eq!(
+        ProjectType::from_str("wasm-app").unwrap(),
+        ProjectType::WasmApp
+    );
+    assert_eq!(
+        ProjectType::from_str("game-engine").unwrap(),
+        ProjectType::GameEngine
+    );
+    assert_eq!(
+        ProjectType::from_str("embedded").unwrap(),
+        ProjectType::Embedded
+    );
+    assert_eq!(
+        ProjectType::from_str("workspace").unwrap(),
+        ProjectType::Workspace
+    );
+
     // Test invalid input
     assert!(ProjectType::from_str("invalid").is_err());
     assert!(ProjectType::from_str("").is_err());

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -55,6 +55,8 @@ mod stress_tests {
                                 i, thread_id
                             )),
                             features: vec![],
+                            target: None,
+                            esp32_chip: None,
                         };
 
                         let output_dir =
@@ -121,6 +123,8 @@ mod stress_tests {
             author: "Test Author".to_string(),
             description: Some("Project with extreme number of files".to_string()),
             features: vec![],
+            target: None,
+            esp32_chip: None
         };
 
         let output_dir = temp_dir.path().join("extreme-files");
@@ -170,6 +174,8 @@ mod stress_tests {
             author: "Test Author".to_string(),
             description: Some("Deeply nested project".to_string()),
             features: vec![],
+            target: None,
+            esp32_chip: None,
         };
 
         let start = Instant::now();
@@ -201,6 +207,8 @@ mod stress_tests {
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
                 features: vec![],
+                target: None,
+                esp32_chip: None,
             };
 
             let output_dir = temp_dir.path().join("panic-test");
@@ -223,6 +231,8 @@ mod stress_tests {
             author: "Test Author".to_string(),
             description: Some("Recovery test".to_string()),
             features: vec![],
+            target: None,
+            esp32_chip: None
         };
 
         let output_dir = temp_dir.path().join("recovery-test");

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -1,7 +1,7 @@
 use cargo_forge::{Generator, ProjectConfig, ProjectType};
 use std::fs;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
@@ -18,20 +18,20 @@ mod stress_tests {
         let total_projects = 100;
         let thread_count = 10;
         let projects_per_thread = total_projects / thread_count;
-        
+
         let success_count = Arc::new(AtomicUsize::new(0));
         let failure_count = Arc::new(AtomicUsize::new(0));
         let start = Instant::now();
-        
+
         let handles: Vec<_> = (0..thread_count)
             .map(|thread_id| {
                 let temp_dir = Arc::clone(&temp_dir);
                 let success_count = Arc::clone(&success_count);
                 let failure_count = Arc::clone(&failure_count);
-                
+
                 thread::spawn(move || {
                     let generator = Generator::new();
-                    
+
                     for i in 0..projects_per_thread {
                         let project_id = thread_id * projects_per_thread + i;
                         let project_types = vec![
@@ -43,19 +43,23 @@ mod stress_tests {
                             ProjectType::Embedded.to_string(),
                             ProjectType::Workspace.to_string(),
                         ];
-                        
+
                         let project_type = &project_types[project_id % project_types.len()];
-                        
+
                         let config = ProjectConfig {
                             name: format!("stress-test-{}-{}", thread_id, i),
                             project_type: project_type.clone(),
                             author: format!("Stress Tester {}", thread_id),
-                            description: Some(format!("Stress test project {} from thread {}", i, thread_id)),
+                            description: Some(format!(
+                                "Stress test project {} from thread {}",
+                                i, thread_id
+                            )),
                             features: vec![],
                         };
-                        
-                        let output_dir = temp_dir.path().join(format!("stress-{}-{}", thread_id, i));
-                        
+
+                        let output_dir =
+                            temp_dir.path().join(format!("stress-{}-{}", thread_id, i));
+
                         match generator.generate(&config, &output_dir) {
                             Ok(_) => {
                                 success_count.fetch_add(1, Ordering::SeqCst);
@@ -72,29 +76,36 @@ mod stress_tests {
                 })
             })
             .collect();
-        
+
         // Wait for all threads
         for handle in handles {
             handle.join().unwrap();
         }
-        
+
         let duration = start.elapsed();
         let successes = success_count.load(Ordering::SeqCst);
         let failures = failure_count.load(Ordering::SeqCst);
-        
+
         println!("Stress test results:");
         println!("  Total projects: {}", total_projects);
         println!("  Successful: {}", successes);
         println!("  Failed: {}", failures);
         println!("  Duration: {:?}", duration);
-        println!("  Projects per second: {:.2}", successes as f64 / duration.as_secs_f64());
-        
+        println!(
+            "  Projects per second: {:.2}",
+            successes as f64 / duration.as_secs_f64()
+        );
+
         // All should succeed
         assert_eq!(successes, total_projects);
         assert_eq!(failures, 0);
-        
+
         // Performance benchmark: should complete within reasonable time
-        assert!(duration < Duration::from_secs(30), "Stress test took too long: {:?}", duration);
+        assert!(
+            duration < Duration::from_secs(30),
+            "Stress test took too long: {:?}",
+            duration
+        );
     }
 
     #[test]
@@ -102,66 +113,75 @@ mod stress_tests {
     fn test_extreme_file_count() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Generate a workspace with many additional files
         let config = ProjectConfig {
             name: "extreme-files".to_string(),
             project_type: ProjectType::Workspace.to_string(),
             author: "Test Author".to_string(),
             description: Some("Project with extreme number of files".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("extreme-files");
         let result = generator.generate(&config, &output_dir);
         assert!(result.is_ok());
-        
+
         // Add thousands of additional source files
         let start = Instant::now();
         for i in 0..1000 {
-            let module_path = output_dir.join("crates/core/src").join(format!("module_{}.rs", i));
-            fs::write(&module_path, format!("// Module {}\npub fn func_{}() {{}}", i, i)).unwrap();
+            let module_path = output_dir
+                .join("crates/core/src")
+                .join(format!("module_{}.rs", i));
+            fs::write(
+                &module_path,
+                format!("// Module {}\npub fn func_{}() {{}}", i, i),
+            )
+            .unwrap();
         }
-        
+
         let duration = start.elapsed();
         println!("Created 1000 additional files in {:?}", duration);
-        
+
         // Count total files
         let file_count = count_files_recursive(&output_dir);
         println!("Total files in project: {}", file_count);
-        
+
         // Should handle large number of files
         assert!(file_count > 1000);
         assert!(duration < Duration::from_secs(10));
     }
 
     #[test]
-    #[ignore] // Use --ignored flag to run this expensive test  
+    #[ignore] // Use --ignored flag to run this expensive test
     fn test_deep_directory_nesting() {
         let temp_dir = TempDir::new().unwrap();
         let generator = Generator::new();
-        
+
         // Create deeply nested project path
         let mut nested_path = temp_dir.path().to_path_buf();
         for i in 0..50 {
             nested_path = nested_path.join(format!("level_{}", i));
         }
-        
+
         let config = ProjectConfig {
             name: "deep-nest".to_string(),
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Deeply nested project".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let start = Instant::now();
         let result = generator.generate(&config, &nested_path);
         let duration = start.elapsed();
-        
-        println!("Deep nesting generation result: {:?}", result.as_ref().err());
+
+        println!(
+            "Deep nesting generation result: {:?}",
+            result.as_ref().err()
+        );
         println!("Duration: {:?}", duration);
-        
+
         // May fail due to OS path length limits, but should handle gracefully
         if result.is_ok() {
             assert!(nested_path.join("Cargo.toml").exists());
@@ -171,7 +191,7 @@ mod stress_tests {
     #[test]
     fn test_recovery_after_panic() {
         let temp_dir = TempDir::new().unwrap();
-        
+
         // Simulate a panic scenario by using catch_unwind
         let result = std::panic::catch_unwind(|| {
             let generator = Generator::new();
@@ -180,21 +200,21 @@ mod stress_tests {
                 project_type: ProjectType::Library.to_string(),
                 author: "Test Author".to_string(),
                 description: Some("Test".to_string()),
-        features: vec![],
+                features: vec![],
             };
-            
+
             let output_dir = temp_dir.path().join("panic-test");
             generator.generate(&config, &output_dir).unwrap();
-            
+
             // Simulate some condition that might panic
             if output_dir.exists() {
                 // Don't actually panic in this test
                 // panic!("Simulated panic!");
             }
         });
-        
+
         assert!(result.is_ok(), "Generator should not panic");
-        
+
         // After "recovery", try generation again
         let generator = Generator::new();
         let config = ProjectConfig {
@@ -202,12 +222,12 @@ mod stress_tests {
             project_type: ProjectType::Library.to_string(),
             author: "Test Author".to_string(),
             description: Some("Recovery test".to_string()),
-        features: vec![],
+            features: vec![],
         };
-        
+
         let output_dir = temp_dir.path().join("recovery-test");
         let result = generator.generate(&config, &output_dir);
-        
+
         assert!(result.is_ok(), "Should be able to generate after recovery");
     }
 

--- a/tests/tera_template_test.rs
+++ b/tests/tera_template_test.rs
@@ -1,17 +1,17 @@
-use tera::{Tera, Context};
-use std::collections::HashMap;
 use serde_json::json;
+use std::collections::HashMap;
+use tera::{Context, Tera};
 
 #[test]
 fn test_tera_basic_rendering() {
     let mut tera = Tera::default();
-    
+
     // Add a simple template
     tera.add_raw_template("test", "Hello, {{ name }}!").unwrap();
-    
+
     let mut context = Context::new();
     context.insert("name", "World");
-    
+
     let result = tera.render("test", &context).unwrap();
     assert_eq!(result, "Hello, World!");
 }
@@ -19,7 +19,7 @@ fn test_tera_basic_rendering() {
 #[test]
 fn test_tera_conditional_rendering() {
     let mut tera = Tera::default();
-    
+
     // Template with conditionals
     let template = r#"
 {%- if has_database %}
@@ -35,14 +35,14 @@ fn main() {
     {%- endif %}
 }
 "#;
-    
+
     tera.add_raw_template("conditional", template).unwrap();
-    
+
     // Test with database enabled
     let mut context = Context::new();
     context.insert("has_database", &true);
     context.insert("has_auth", &false);
-    
+
     let result = tera.render("conditional", &context).unwrap();
     assert!(result.contains("use sqlx::PgPool;"));
     assert!(!result.contains("use jsonwebtoken::decode;"));
@@ -52,23 +52,26 @@ fn main() {
 #[test]
 fn test_tera_loops_and_arrays() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 [dependencies]
 {%- for dep in dependencies %}
 {{ dep.name }} = "{{ dep.version }}"
 {%- endfor %}
 "#;
-    
+
     tera.add_raw_template("deps", template).unwrap();
-    
+
     let mut context = Context::new();
-    context.insert("dependencies", &vec![
-        json!({"name": "tokio", "version": "1.0"}),
-        json!({"name": "serde", "version": "1.0"}),
-        json!({"name": "axum", "version": "0.7"}),
-    ]);
-    
+    context.insert(
+        "dependencies",
+        &vec![
+            json!({"name": "tokio", "version": "1.0"}),
+            json!({"name": "serde", "version": "1.0"}),
+            json!({"name": "axum", "version": "0.7"}),
+        ],
+    );
+
     let result = tera.render("deps", &context).unwrap();
     assert!(result.contains("tokio = \"1.0\""));
     assert!(result.contains("serde = \"1.0\""));
@@ -78,7 +81,7 @@ fn test_tera_loops_and_arrays() {
 #[test]
 fn test_tera_project_type_specific_rendering() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 # {{ project_name }}
 
@@ -112,23 +115,23 @@ cargo build --target wasm32-unknown-unknown
 ```
 {%- endif %}
 "#;
-    
+
     tera.add_raw_template("readme", template).unwrap();
-    
+
     // Test API server README
     let mut context = Context::new();
     context.insert("project_name", "My API");
     context.insert("project_type", "api-server");
-    
+
     let result = tera.render("readme", &context).unwrap();
     assert!(result.contains("# My API"));
     assert!(result.contains("An API server built with Axum"));
     assert!(result.contains("http://localhost:3000"));
-    
+
     // Test game engine README
     context.insert("project_name", "My Game");
     context.insert("project_type", "game-engine");
-    
+
     let result = tera.render("readme", &context).unwrap();
     assert!(result.contains("# My Game"));
     assert!(result.contains("A game built with Bevy"));
@@ -138,7 +141,7 @@ cargo build --target wasm32-unknown-unknown
 #[test]
 fn test_tera_nested_conditionals() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 {%- if project_type == "api-server" %}
 use axum::Router;
@@ -158,17 +161,17 @@ async fn main() {
 }
 {%- endif %}
 "#;
-    
+
     tera.add_raw_template("nested", template).unwrap();
-    
+
     let mut context = Context::new();
     context.insert("project_type", "api-server");
-    
+
     let mut features = HashMap::new();
     features.insert("database", true);
     features.insert("auth", true);
     context.insert("features", &features);
-    
+
     let result = tera.render("nested", &context).unwrap();
     assert!(result.contains("use axum::Router;"));
     assert!(result.contains("use sqlx::PgPool;"));
@@ -179,7 +182,7 @@ async fn main() {
 #[test]
 fn test_tera_workspace_members_rendering() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 [workspace]
 resolver = "2"
@@ -193,14 +196,14 @@ members = [
 version = "{{ version }}"
 authors = ["{{ author }}"]
 "#;
-    
+
     tera.add_raw_template("workspace", template).unwrap();
-    
+
     let mut context = Context::new();
     context.insert("members", &vec!["crates/core", "crates/api", "crates/cli"]);
     context.insert("version", "0.1.0");
     context.insert("author", "Test Author");
-    
+
     let result = tera.render("workspace", &context).unwrap();
     assert!(result.contains("\"crates/core\","));
     assert!(result.contains("\"crates/api\","));
@@ -212,7 +215,7 @@ authors = ["{{ author }}"]
 #[test]
 fn test_tera_embedded_memory_config() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 MEMORY
 {
@@ -220,15 +223,15 @@ MEMORY
   RAM : ORIGIN = 0x{{ ram_origin }}, LENGTH = {{ ram_size }}K
 }
 "#;
-    
+
     tera.add_raw_template("memory", template).unwrap();
-    
+
     let mut context = Context::new();
     context.insert("flash_origin", "08000000");
     context.insert("flash_size", &256);
     context.insert("ram_origin", "20000000");
     context.insert("ram_size", &64);
-    
+
     let result = tera.render("memory", &context).unwrap();
     assert!(result.contains("FLASH : ORIGIN = 0x08000000, LENGTH = 256K"));
     assert!(result.contains("RAM : ORIGIN = 0x20000000, LENGTH = 64K"));
@@ -237,7 +240,7 @@ MEMORY
 #[test]
 fn test_tera_feature_combinations() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 [dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -258,12 +261,12 @@ tower = "0.4"
 testcontainers = "0.15"
 {%- endif %}
 "#;
-    
+
     tera.add_raw_template("features", template).unwrap();
-    
+
     let mut context = Context::new();
     context.insert("features", &vec!["database", "api", "docker"]);
-    
+
     let result = tera.render("features", &context).unwrap();
     assert!(result.contains("sqlx = { version = \"0.7\""));
     assert!(result.contains("axum = \"0.7\""));
@@ -274,14 +277,14 @@ testcontainers = "0.15"
 #[test]
 fn test_tera_error_handling() {
     let mut tera = Tera::default();
-    
+
     // Template with undefined variable
     let template = "Hello, {{ undefined_var }}!";
     tera.add_raw_template("error", template).unwrap();
-    
+
     let context = Context::new();
     let result = tera.render("error", &context);
-    
+
     // Should fail when trying to use undefined variable
     assert!(result.is_err());
 }
@@ -289,18 +292,18 @@ fn test_tera_error_handling() {
 #[test]
 fn test_tera_filters() {
     let mut tera = Tera::default();
-    
+
     let template = r#"
 Project: {{ name | upper }}
 Snake case: {{ name | replace(from="-", to="_") }}
 Title case: {{ name | title }}
 "#;
-    
+
     tera.add_raw_template("filters", template).unwrap();
-    
+
     let mut context = Context::new();
     context.insert("name", "my-awesome-project");
-    
+
     let result = tera.render("filters", &context).unwrap();
     assert!(result.contains("Project: MY-AWESOME-PROJECT"));
     assert!(result.contains("Snake case: my_awesome_project"));

--- a/tests/validation_test.rs
+++ b/tests/validation_test.rs
@@ -5,11 +5,11 @@ use tempfile::TempDir;
 fn test_project_name_validation_comprehensive() {
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Valid project names
     let valid_names = vec![
         "my-project",
-        "my_project", 
+        "my_project",
         "myproject123",
         "a",
         "_project",
@@ -17,7 +17,7 @@ fn test_project_name_validation_comprehensive() {
         "dash-project",
         "alpha123numeric",
     ];
-    
+
     for name in valid_names {
         assert!(
             forge.validate_project_name(name).is_ok(),
@@ -25,8 +25,8 @@ fn test_project_name_validation_comprehensive() {
             name
         );
     }
-    
-    // Invalid project names  
+
+    // Invalid project names
     let invalid_names = vec![
         ("", "Project name cannot be empty"),
         ("My-Project", "Project name must be lowercase"),
@@ -35,33 +35,53 @@ fn test_project_name_validation_comprehensive() {
         ("123project", "Project name cannot start with a number"),
         ("-project", "Project name cannot start with '-' or '_'"),
         ("project-", "Project name cannot end with '-' or '_'"),
-        ("my--project", "Project name cannot contain consecutive dashes or underscores"),
-        ("my__project", "Project name cannot contain consecutive dashes or underscores"),
+        (
+            "my--project",
+            "Project name cannot contain consecutive dashes or underscores",
+        ),
+        (
+            "my__project",
+            "Project name cannot contain consecutive dashes or underscores",
+        ),
         ("test", "'test' is a reserved name"),
         ("main", "'main' is a reserved name"),
         ("cargo", "'cargo' is a reserved name"),
         ("src", "'src' is a reserved name"),
-        ("this-is-a-very-long-project-name-that-exceeds-the-maximum-allowed-length-of-64-chars", "Project name is too long (max 64 characters)"),
-        ("my!project", "Project name can only contain letters, numbers, '-', and '_'"),
-        ("my@project", "Project name can only contain letters, numbers, '-', and '_'"),
-        ("my#project", "Project name can only contain letters, numbers, '-', and '_'"),
+        (
+            "this-is-a-very-long-project-name-that-exceeds-the-maximum-allowed-length-of-64-chars",
+            "Project name is too long (max 64 characters)",
+        ),
+        (
+            "my!project",
+            "Project name can only contain letters, numbers, '-', and '_'",
+        ),
+        (
+            "my@project",
+            "Project name can only contain letters, numbers, '-', and '_'",
+        ),
+        (
+            "my#project",
+            "Project name can only contain letters, numbers, '-', and '_'",
+        ),
     ];
-    
+
     for (name, expected_error) in invalid_names {
         let result = forge.validate_project_name(name);
         assert!(
             result.is_err(),
-            "Expected '{}' to be invalid, but it was accepted", 
+            "Expected '{}' to be invalid, but it was accepted",
             name
         );
-        
+
         if result.is_err() {
             let error_msg = result.unwrap_err().to_string();
             println!("Testing '{}': {}", name, error_msg);
             // Check that we get an appropriate error message
             assert!(
-                error_msg.contains(expected_error) || 
-                error_msg.to_lowercase().contains(&expected_error.to_lowercase()),
+                error_msg.contains(expected_error)
+                    || error_msg
+                        .to_lowercase()
+                        .contains(&expected_error.to_lowercase()),
                 "For '{}', expected error containing '{}', but got '{}'",
                 name,
                 expected_error,
@@ -75,56 +95,65 @@ fn test_project_name_validation_comprehensive() {
 fn test_validation_called_in_non_interactive_mode() {
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Test that invalid names are rejected in non-interactive mode
     let result = forge.run_non_interactive(
         Some("123-invalid".to_string()),
         Some("cli-tool".to_string()),
         None,
         None,
-        None
+        None,
     );
-    
-    assert!(result.is_err(), "Should reject invalid project name in non-interactive mode");
-    assert!(result.unwrap_err().to_string().contains("cannot start with a number"));
+
+    assert!(
+        result.is_err(),
+        "Should reject invalid project name in non-interactive mode"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("cannot start with a number"));
 }
 
-#[test] 
+#[test]
 fn test_validation_called_in_with_args_mode() {
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Test that invalid names are rejected when using args
     let result = forge.run_with_args(
         Some("MY-PROJECT".to_string()),
         Some("cli-tool".to_string()),
         None,
-        None
+        None,
     );
-    
-    assert!(result.is_err(), "Should reject invalid project name in with_args mode");
-    assert!(result.unwrap_err().to_string().contains("must be lowercase"));
+
+    assert!(
+        result.is_err(),
+        "Should reject invalid project name in with_args mode"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("must be lowercase"));
 }
 
 #[test]
 fn test_validation_called_in_from_config_mode() {
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Create a dummy config file
     let config_path = temp_dir.path().join("config.json");
     std::fs::write(&config_path, r#"{"default_author":"test","default_license":"MIT","preferred_project_types":["cli-tool"],"default_features":{},"edition":"2021"}"#).unwrap();
-    
+
     // Test that invalid names are rejected when using config
-    let result = forge.run_from_config(
-        config_path,
-        Some("project-".to_string()),
-        None,
-        None,
-        None
+    let result = forge.run_from_config(config_path, Some("project-".to_string()), None, None, None);
+
+    assert!(
+        result.is_err(),
+        "Should reject invalid project name in from_config mode"
     );
-    
-    assert!(result.is_err(), "Should reject invalid project name in from_config mode");
     assert!(result.unwrap_err().to_string().contains("cannot end with"));
 }
 
@@ -132,7 +161,7 @@ fn test_validation_called_in_from_config_mode() {
 fn test_validation_called_in_dry_run_mode() {
     let temp_dir = TempDir::new().unwrap();
     let forge = Forge::new(temp_dir.path());
-    
+
     // Test that invalid names are rejected in dry run mode
     let result = forge.run_dry_run(
         Some("my/project".to_string()),
@@ -140,9 +169,15 @@ fn test_validation_called_in_dry_run_mode() {
         None,
         None,
         true, // non_interactive
-        None
+        None,
     );
-    
-    assert!(result.is_err(), "Should reject invalid project name in dry_run mode");
-    assert!(result.unwrap_err().to_string().contains("cannot contain slashes"));
+
+    assert!(
+        result.is_err(),
+        "Should reject invalid project name in dry_run mode"
+    );
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("cannot contain slashes"));
 }


### PR DESCRIPTION
Hi @marcuspat , 
I really loved your tool and the ease of project creation it gives. 

But I noticed one small thing, you have the same templates for Cortex-M based applications and ESP32 applications. 

Since both are completely different, I took the liberty of adding an extra step where you will have to choose between Corex-M based and ESP32 based applications as shown in the image. 

<img width="1495" height="464" alt="image" src="https://github.com/user-attachments/assets/9adff7d1-50ee-402b-9b4a-c764ae0115f7" />

If you choose the ESP32 option, it will open up the `esp-generate` tool, which is used to create projects for ESP32 boards. 

Hope it helps. 

Regards,
Vaishnav-Sabari-Girish